### PR TITLE
Changed the context to be forced preview

### DIFF
--- a/src/Controllers/BlockPreviewApiController.cs
+++ b/src/Controllers/BlockPreviewApiController.cs
@@ -104,6 +104,7 @@ namespace Our.Umbraco.BlockPreview.Controllers
             var requestBuilder = await _publishedRouter.CreateRequestAsync(new Uri(Request.GetDisplayUrl()));
             requestBuilder.SetPublishedContent(page);
             context.PublishedRequest = requestBuilder.Build();
+            context.ForcedPreview(true);
 
             // if in a culture variant setup also set the correct language.
             var currentCulture = string.IsNullOrWhiteSpace(culture)


### PR DESCRIPTION
Changed the context to be "Forced Preview" this allows us to be able to distinguish that a request is coming from the Backoffice when rendering the blocks.

This could be used alongside IsVisible to keep blocks visible in the Backoffice

Fixes #4