### PR TITLE
Added IsBlockPreview

### DIFF
--- a/src/Extensions/UmbracoContextExtensions.cs
+++ b/src/Extensions/UmbracoContextExtensions.cs
@@ -6,7 +6,7 @@ namespace Our.Umbraco.BlockPreview.Extensions
 {
     public static class UmbracoContextExtensions
     {
-        public static bool IsBlockPreview(this IUmbracoContext umbracoContext, HttpContext httpContext)
+        public static bool IsBlockPreview(this IUmbracoContext _, HttpContext httpContext)
         {
             var requestControllerName = (string)httpContext.Request.RouteValues["controller"] + "Controller";
             if (requestControllerName.Equals	(nameof(BlockPreviewApiController)) && httpContext.Request.RouteValues["action"].Equals	(nameof(BlockPreviewApiController.PreviewMarkup)))

--- a/src/Extensions/UmbracoContextExtensions.cs
+++ b/src/Extensions/UmbracoContextExtensions.cs
@@ -1,18 +1,18 @@
-﻿using System;
+﻿using Our.Umbraco.BlockPreview.Controllers;
 using Umbraco.Cms.Core.Web;
+using HttpContext = Microsoft.AspNetCore.Http.HttpContext;
 
 namespace Our.Umbraco.BlockPreview.Extensions
 {
     public static class UmbracoContextExtensions
     {
-        public static bool IsBlockPreview(this IUmbracoContext umbracoContext)
+        public static bool IsBlockPreview(this IUmbracoContext umbracoContext, HttpContext httpContext)
         {
-            if (umbracoContext.OriginalRequestUrl.LocalPath.Contains("blockpreviewapi",
-                    StringComparison.InvariantCultureIgnoreCase))
+            var requestControllerName = (string)httpContext.Request.RouteValues["controller"] + "Controller";
+            if (requestControllerName.Equals	(nameof(BlockPreviewApiController)) && httpContext.Request.RouteValues["action"].Equals	(nameof(BlockPreviewApiController.PreviewMarkup)))
             {
                 return true;
             }
-
             return false;
         }
     }

--- a/src/Extensions/UmbracoContextExtensions.cs
+++ b/src/Extensions/UmbracoContextExtensions.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Umbraco.Cms.Core.Web;
+
+namespace Our.Umbraco.BlockPreview.Extensions
+{
+    public static class UmbracoContextExtensions
+    {
+        public static bool IsBlockPreview(this IUmbracoContext umbracoContext)
+        {
+            if (umbracoContext.OriginalRequestUrl.LocalPath.Contains("blockpreviewapi",
+                    StringComparison.InvariantCultureIgnoreCase))
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Extensions/UmbracoContextExtensions.cs
+++ b/src/Extensions/UmbracoContextExtensions.cs
@@ -9,11 +9,7 @@ namespace Our.Umbraco.BlockPreview.Extensions
         public static bool IsBlockPreview(this IUmbracoContext _, HttpContext httpContext)
         {
             var requestControllerName = (string)httpContext.Request.RouteValues["controller"] + "Controller";
-            if (requestControllerName.Equals	(nameof(BlockPreviewApiController)) && httpContext.Request.RouteValues["action"].Equals	(nameof(BlockPreviewApiController.PreviewMarkup)))
-            {
-                return true;
-            }
-            return false;
+            return requestControllerName.Equals	(nameof(BlockPreviewApiController)) && httpContext.Request.RouteValues["action"].Equals	(nameof(BlockPreviewApiController.PreviewMarkup));
         }
     }
 }


### PR DESCRIPTION
Added `IsBlockPreview()` extension.

There might be a better more fool proof way to do this check, but I've made it check that the request url contains `blockpreviewapi`