### PR TITLE
Added some spacing and a border to the blocks.

### DIFF
--- a/src/App_Plugins/Our.Umbraco.BlockPreview/css/blockpreview.css
+++ b/src/App_Plugins/Our.Umbraco.BlockPreview/css/blockpreview.css
@@ -1,0 +1,5 @@
+﻿.block-preview-spacing {
+    margin-top: 4px;
+    border: 1px solid #e9e9eb;
+    color: #1b264f;
+}

--- a/src/App_Plugins/Our.Umbraco.BlockPreview/package.manifest
+++ b/src/App_Plugins/Our.Umbraco.BlockPreview/package.manifest
@@ -7,5 +7,8 @@
     "~/App_Plugins/Our.Umbraco.BlockPreview/js/directives/published-check.directive.js",
     "~/App_Plugins/Our.Umbraco.BlockPreview/js/directives/bind-compile.directive.js",
     "~/App_Plugins/Our.Umbraco.BlockPreview/js/controllers/block-preview.controller.js"
+  ],
+  "css": [
+    "~/App_Plugins/Our.Umbraco.BlockPreview/css/blockpreview.css"
   ]
 }

--- a/src/App_Plugins/Our.Umbraco.BlockPreview/views/block-preview.html
+++ b/src/App_Plugins/Our.Umbraco.BlockPreview/views/block-preview.html
@@ -1,4 +1,11 @@
-﻿<div ng-click="block.edit(); $event.stopPropagation()" ng-focus="block.focus" class="blockelement__draggable-element" ng-controller="Our.Umbraco.BlockPreview.Controllers.BlockPreviewController">
+﻿<style>
+    .block-preview-spacing {
+        margin-top: 4px;
+        border: 1px solid #e9e9eb;
+        color: #1b264f;
+    }
+</style>
+<div ng-click="block.edit(); $event.stopPropagation()" ng-focus="block.focus" class="blockelement__draggable-element block-preview-spacing" ng-controller="Our.Umbraco.BlockPreview.Controllers.BlockPreviewController">
 
     <div ng-if="loading === false"
          ng-bind-compile="markup"

--- a/src/Our.Umbraco.BlockPreview.csproj
+++ b/src/Our.Umbraco.BlockPreview.csproj
@@ -48,6 +48,7 @@
 			<Pack>true</Pack>
 			<PackagePath>buildTransitive</PackagePath>
 		</None>
+		<None Remove="App_Plugins\Our.Umbraco.BlockPreview\css\blockpreview.css" />
 		<None Include="..\.github\readme-assets\icon.png">
 			<Pack>True</Pack>
 			<PackagePath>\</PackagePath>


### PR DESCRIPTION
I have added a 4px top margin plus a border to make the blocks distinguishable with each other.

![image](https://user-images.githubusercontent.com/9937803/216609341-c8918d8d-9b4a-47a7-89fc-f0a3cf027637.png)

I was unable to the css stylesheet to load so it's also inline, not sure if that's a limitation of the backoffice?

Fixes #5