### PR TITLE
Adds fallback to culture defined on node

### DIFF
--- a/src/App_Plugins/Umbraco.Community.BlockPreview/js/controllers/block-preview.controller.js
+++ b/src/App_Plugins/Umbraco.Community.BlockPreview/js/controllers/block-preview.controller.js
@@ -21,8 +21,8 @@
 
                 var formattedBlockData = {
                     layout: $scope.block.layout,
-                    contentData: [content ?? $scope.block.data],
-                    settingsData: [settings ?? $scope.block.settingsData]
+                    contentData: [content || $scope.block.data],
+                    settingsData: [settings || $scope.block.settingsData]
                 };
 
                 previewResource.getPreview(formattedBlockData, $scope.id, $scope.model.constructor.name == 'BlockGridBlockController', $scope.language).then(function (data) {


### PR DESCRIPTION
This update fixes a null exception when the scope has no language set.

**Explanantion**
For invariant content the language property is always null for the variant. The call to SetCulture will throw a null exception when passed a null value. In that case we need to set the language on the scope by retrieving the culture information for that node and use that to set the language. 
