### PR TITLE
Linux casesensetive view-paths

### DIFF
--- a/src/Umbraco.Community.BlockPreview/Services/BackOfficeGridPreviewService.cs
+++ b/src/Umbraco.Community.BlockPreview/Services/BackOfficeGridPreviewService.cs
@@ -117,7 +117,7 @@ namespace Umbraco.Community.BlockPreview.Services
             viewData.Model = blockInstance;
             viewData["blockPreview"] = true;
 
-            string contentAlias = contentElement.ContentType.Alias.ToFirstUpper();
+            string contentAlias = contentElement.ContentType.Alias;
             ViewComponentDescriptor viewComponent = _viewComponentSelector.SelectComponent(contentAlias);
 
             var cultureInfo = new CultureInfo(culture);

--- a/src/Umbraco.Community.BlockPreview/Services/BackOfficeListPreviewService.cs
+++ b/src/Umbraco.Community.BlockPreview/Services/BackOfficeListPreviewService.cs
@@ -105,7 +105,7 @@ namespace Umbraco.Community.BlockPreview.Services
             viewData.Model = blockInstance;
             viewData["blockPreview"] = true;
 
-            string contentAlias = contentElement.ContentType.Alias.ToFirstUpper();
+            string contentAlias = contentElement.ContentType.Alias;
             ViewComponentDescriptor viewComponent = _viewComponentSelector.SelectComponent(contentAlias);
 
             if (viewComponent != null)


### PR DESCRIPTION
**Issue**:
View-lookup is casesensetive on Linux and "ToFirstUpper()" prevents using aliases in camelCase.

**Idea**:
Umbraco defaults doctype-aliases to camelCase so I think the best would be to leave the alias as it is 🙂


Exception when using Linux.
```
System.IO.DirectoryNotFoundException: Could not find a part of the path '/var/www/....../Views/Partials/blockgrid/Components/MapModule.cshtml'.
   at Interop.ThrowExceptionForIoErrno(ErrorInfo errorInfo, String path, Boolean isDirError)
   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, UnixFileMode openPermissions, Int64& fileLength, UnixFileMode& filePermissions, Func`4 createOpenException)
   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)
   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options)
   at Microsoft.Extensions.FileProviders.Physical.PhysicalFileInfo.CreateReadStream()
   at Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation.FileProviderRazorProjectItem.Read()
   at Microsoft.AspNetCore.Razor.Language.RazorSourceDocument.ReadFrom(RazorProjectItem projectItem)
   at Microsoft.AspNetCore.Razor.Language.DefaultRazorProjectEngine.CreateCodeDocumentCore(RazorProjectItem projectItem, Action`1 configureParser, Action`1 configureCodeGeneration)
   at Microsoft.AspNetCore.Razor.Language.DefaultRazorProjectEngine.CreateCodeDocumentCore(RazorProjectItem projectItem)
   at Microsoft.AspNetCore.Razor.Language.RazorProjectEngine.Process(RazorProjectItem projectItem)
   at Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation.RuntimeViewCompiler.CompileAndEmit(String relativePath)
   at Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation.RuntimeViewCompiler.OnCacheMiss(String normalizedPath)
--- End of stack trace from previous location ---
   at Microsoft.AspNetCore.Mvc.Razor.Compilation.DefaultRazorPageFactoryProvider.CreateFactory(String relativePath)
   at Microsoft.AspNetCore.Mvc.Razor.RazorViewEngine.CreateCacheResult(HashSet`1 expirationTokens, String relativePath, Boolean isMainPage)
   at Microsoft.AspNetCore.Mvc.Razor.RazorViewEngine.OnCacheMiss(ViewLocationExpanderContext expanderContext, ViewLocationCacheKey cacheKey)
   at Microsoft.AspNetCore.Mvc.Razor.RazorViewEngine.LocatePageFromViewLocations(ActionContext actionContext, String pageName, Boolean isMainPage)
   at Microsoft.AspNetCore.Mvc.Razor.RazorViewEngine.FindView(ActionContext context, String viewName, Boolean isMainPage)
   at Umbraco.Community.BlockPreview.Services.BackOfficePreviewService.GetMarkupFromPartial(ControllerContext controllerContext, ViewDataDictionary viewData, String contentAlias)
   at Umbraco.Community.BlockPreview.Services.BackOfficeGridPreviewService.GetMarkupForBlock(BlockValue blockValue, ControllerContext controllerContext, String culture)
   at Umbraco.Community.BlockPreview.Controllers.BlockPreviewApiController.PreviewMarkup(BlockValue data, Int32 pageId, Boolean isGrid, String culture)
```