### PR TITLE
Remove link to umbraco.min.css

### DIFF
--- a/src/Umbraco.Community.BlockPreview/App_Plugins/Umbraco.Community.BlockPreview/views/block-preview.html
+++ b/src/Umbraco.Community.BlockPreview/App_Plugins/Umbraco.Community.BlockPreview/views/block-preview.html
@@ -1,5 +1,3 @@
-﻿<link rel="stylesheet" href="/umbraco/assets/css/umbraco.min.css" />
-
 <div ng-click="editBlock($event, block)" ng-focus="block.focus" class="blockelement__draggable-element" ng-class="{ '--active': block.active, '--error': parentForm.$invalid && valFormManager.isShowingValidation() }" ng-controller="Umbraco.Community.BlockPreview.Controllers.BlockPreviewController">
 
     <div ng-if="loading === false"


### PR DESCRIPTION
This was already added as part of the back office
Rick had added it with a cache buster to style error messages However, it was over-riding the users own css
Removing it does seem to work although some of the users css is still not being displayed