### PR TITLE
fix: validate if file is maybe writter in pascal case if view is not found by camel case

### DIFF
--- a/src/Umbraco.Community.BlockPreview/Extensions/StringExtensions.cs
+++ b/src/Umbraco.Community.BlockPreview/Extensions/StringExtensions.cs
@@ -1,0 +1,16 @@
+﻿using System.Globalization;
+
+namespace Umbraco.Community.BlockPreview.Extensions;
+
+public static class StringExtensions
+{
+    public static string ToPascalCase(this string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return value;
+        }
+
+        return $"{char.ToUpper(value[0], CultureInfo.CurrentCulture)}{value[1..]}";
+    }
+}

--- a/src/Umbraco.Community.BlockPreview/Services/BackOfficePreviewService.cs
+++ b/src/Umbraco.Community.BlockPreview/Services/BackOfficePreviewService.cs
@@ -50,7 +50,7 @@ namespace Umbraco.Community.BlockPreview.Services
                 if (!viewResult.Success)
                 {
                     
-                     formattedViewPath = string.Format($"~{viewPath}", contentAlias.CapitaliaseFirstLetter());
+                     formattedViewPath = string.Format($"~{viewPath}", contentAlias.ToPascalCase());
                          viewResult = _razorViewEngine.GetView("", formattedViewPath, false);
                          if (!viewResult.Success)
                          {

--- a/src/Umbraco.Community.BlockPreview/Services/BackOfficePreviewService.cs
+++ b/src/Umbraco.Community.BlockPreview/Services/BackOfficePreviewService.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Options;
 using System.IO;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
+using Umbraco.Community.BlockPreview.Extensions;
 using Umbraco.Community.BlockPreview.Interfaces;
 
 namespace Umbraco.Community.BlockPreview.Services
@@ -47,7 +48,16 @@ namespace Umbraco.Community.BlockPreview.Services
                 ViewEngineResult viewResult = _razorViewEngine.GetView("", formattedViewPath, false);
 
                 if (!viewResult.Success)
-                    continue;
+                {
+                    
+                     formattedViewPath = string.Format($"~{viewPath}", contentAlias.CapitaliaseFirstLetter());
+                         viewResult = _razorViewEngine.GetView("", formattedViewPath, false);
+                         if (!viewResult.Success)
+                         {
+                             continue;
+                         }
+                }
+
 
                 var actionContext = new ActionContext(controllerContext.HttpContext, new RouteData(), new ActionDescriptor());
                 if (viewResult?.View == null)

--- a/src/Umbraco.Community.BlockPreview/Umbraco.Community.BlockPreview.csproj
+++ b/src/Umbraco.Community.BlockPreview/Umbraco.Community.BlockPreview.csproj
@@ -16,8 +16,8 @@
 		<RootNamespace>Umbraco.Community.BlockPreview</RootNamespace>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 
-		<VersionPrefix>1.8.0</VersionPrefix>
-		<VersionSuffix></VersionSuffix>
+		<VersionPrefix>1.8.1</VersionPrefix>
+		<VersionSuffix>etch-beta.2</VersionSuffix>
 		<Authors>Rick Butterfield, Dave Woestenborghs, Matthew Wise</Authors>
 		<Copyright>$([System.DateTime]::UtcNow.ToString(`yyyy`)) © Rick Butterfield</Copyright>
 

--- a/src/Umbraco.Community.BlockPreview/Umbraco.Community.BlockPreview.csproj
+++ b/src/Umbraco.Community.BlockPreview/Umbraco.Community.BlockPreview.csproj
@@ -16,8 +16,8 @@
 		<RootNamespace>Umbraco.Community.BlockPreview</RootNamespace>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 
-		<VersionPrefix>1.8.1</VersionPrefix>
-		<VersionSuffix>etch-beta.2</VersionSuffix>
+		<VersionPrefix>1.8.0</VersionPrefix>
+		<VersionSuffix></VersionSuffix>
 		<Authors>Rick Butterfield, Dave Woestenborghs, Matthew Wise</Authors>
 		<Copyright>$([System.DateTime]::UtcNow.ToString(`yyyy`)) © Rick Butterfield</Copyright>
 


### PR DESCRIPTION
When using linux, there might be issue when using Pascal case for views, as aliast is lower case in begining always, and Pascal is Upper case first.