### PR TITLE
Fix re-sizable BlockGridItems

### DIFF
--- a/src/Umbraco.Community.BlockPreview/Services/BlockPreviewService.cs
+++ b/src/Umbraco.Community.BlockPreview/Services/BlockPreviewService.cs
@@ -105,16 +105,31 @@ namespace Umbraco.Community.BlockPreview.Services
             if (blockInstance == null)
                 return string.Empty;
 
-            string? layoutItemJson = blockData?.Layout?.FirstOrDefault().Value.FirstOrDefault()!.ToString();
+            List<string>? layoutItems = blockData?.Layout?.FirstOrDefault().Value.Select(layout => layout.ToString()).ToList();
             BlockGridLayoutItem? layoutItem = null;
 
-            if (!string.IsNullOrEmpty(layoutItemJson))
+            foreach (var layoutItemJson in layoutItems)
             {
                 layoutItem = JsonConvert.DeserializeObject<BlockGridLayoutItem>(layoutItemJson);
                 if (layoutItem != null)
                 {
-                    blockInstance.RowSpan = layoutItem.RowSpan!.Value;
-                    blockInstance.ColumnSpan = layoutItem.ColumnSpan!.Value;
+                    if (layoutItem.ContentUdi == blockInstance.ContentUdi)
+                    {
+                        blockInstance.RowSpan = layoutItem.RowSpan!.Value;
+                        blockInstance.ColumnSpan = layoutItem.ColumnSpan!.Value;
+                    }
+                    else
+                    {
+                        foreach (var area in layoutItem.Areas)
+                        {
+                            foreach (var item in area.Items)
+                            {
+                                if (item.ContentUdi != blockInstance.ContentUdi) continue;
+                                blockInstance.RowSpan = item.RowSpan!.Value;
+                                blockInstance.ColumnSpan = item.ColumnSpan!.Value;
+                            }
+                        }
+                    }
                 }
             }
 

--- a/src/Umbraco.Community.BlockPreview/wwwroot/App_Plugins/Umbraco.Community.BlockPreview/js/controllers/block-preview.controller.js
+++ b/src/Umbraco.Community.BlockPreview/wwwroot/App_Plugins/Umbraco.Community.BlockPreview/js/controllers/block-preview.controller.js
@@ -132,6 +132,26 @@
 
             var timeoutPromise;
 
+            $scope.$watch('block.layout.columnSpan', function (newValue, oldValue) {
+                if (newValue !== oldValue) {
+                    $timeout.cancel(timeoutPromise);
+
+                    timeoutPromise = $timeout(function () {   //Set timeout
+                        loadPreview(newValue, null);
+                    }, 500);
+                }
+            }, true);
+
+            $scope.$watch('block.layout.rowSpan', function (newValue, oldValue) {
+                if (newValue !== oldValue) {
+                    $timeout.cancel(timeoutPromise);
+
+                    timeoutPromise = $timeout(function () {   //Set timeout
+                        loadPreview(newValue, null);
+                    }, 500);
+                }
+            }, true);
+
             $scope.$watch('block.data', function (newValue, oldValue) {
                 if (newValue !== oldValue) {
                     $timeout.cancel(timeoutPromise);


### PR DESCRIPTION
# BlockPreview - Resizable BlockGridItems

## Incorrectly assigning ColumnSpan & RowSpan values
Block Preview incorrectly assigns Model.ColumnSpan and Model.RowSpan values to BlockGridItems when being displayed in the back-office. 

**Fix:** Iterated over the layoutItems present in blockData and checked each entry for a matching ContentUdi before assigning the ColumnSpan and RowSpan values.

## Added watch values for block element resize
BlockPreview does not watch for changes to BlockGridItem ColumnSpan or RowSpan values. When a block element is resized within the back-office, the view is not re-rendered.

**Change:** Added additional watch values to the Angular controller to re-render block elements that have been resized within the back-office.

