### PR TITLE
fix: Updated umbraco-package JS path to work on case-sensitive systems.

### DIFF
--- a/src/Umbraco.Community.BlockPreview.UI/public/umbraco-package.json
+++ b/src/Umbraco.Community.BlockPreview.UI/public/umbraco-package.json
@@ -9,7 +9,7 @@
       "name": "Umbraco.Community.BlockPreview.EntryPoint",
       "alias": "Umbraco.Community.BlockPreview.EntryPoint",
       "type": "entryPoint",
-      "js": "/app_plugins/Umbraco.Community.BlockPreview/assets.js"
+      "js": "/App_Plugins/Umbraco.Community.BlockPreview/assets.js"
     }
   ]
 }


### PR DESCRIPTION
## Issue
The "js" file path entry for umbraco-package.json in the Umbraco.Community.BlockPreview.UI project has mismatching casing when compared to the actual folder path. This breaks on case-sensitive operating systems.

## Fix
The file path has been updated to match the casing of the folder path. This should now be working as expected, tested via Ubuntu WSL.

Fixes #68 