### PR TITLE
fix: additional styling to match Umbraco.BlockGrid.ExampleWebsite

### DIFF
--- a/src/Umbraco.Cms.11.x/wwwroot/css/myblockgridlayout.css
+++ b/src/Umbraco.Cms.11.x/wwwroot/css/myblockgridlayout.css
@@ -94,6 +94,14 @@
     }
 }
 
+.blockelement__draggable-element {
+    height: 100%;
+}
+
+.blockelement__draggable-element > div:first-of-type {
+    height: 100%;
+}
+
 section {
     padding: var(--section-padding, 60px 0);
 }
@@ -128,20 +136,20 @@ h2 {
 
 /**umb_name:H3*/
 h3 {
-	font-size: 30px;
-	font-weight: 300;
-	line-height: 1.2;
-	margin:0;
-	color: inherit;
+    font-size: 30px;
+    font-weight: 300;
+    line-height: 1.2;
+    margin:0;
+    color: inherit;
 }
 
 /**umb_name:H4*/
 h4 {
-	font-size: 21px;
-	font-weight: 300;
-	line-height: 1.2;
-	margin:0;
-	color: inherit;
+    font-size: 21px;
+    font-weight: 300;
+    line-height: 1.2;
+    margin:0;
+    color: inherit;
 }
 
 
@@ -184,7 +192,7 @@ p.lead-paragraph {
 
 /** Hero */
 
-.umb-block-grid__layout-item[data-content-element-type-alias="heroBlock"] .umb-block-grid__area-container, 
+.umb-block-grid__layout-item[data-content-element-type-alias="heroBlock"] .umb-block-grid__area-container,
 .umb-block-grid__layout-item[data-content-element-type-alias="heroBlock"] .umb-block-grid__block--view::part(area-container) {
     padding: 0;
 }
@@ -264,7 +272,7 @@ p.lead-paragraph {
     padding: var(--my-container-padding);
     margin-left: auto;
     margin-right: auto;
-    
+
     display: grid;
     grid-template-columns: 1fr 1fr 1fr 1fr;
     grid-auto-flow: row;
@@ -312,6 +320,7 @@ p.lead-paragraph {
     height: 100%;
     color: black;
     background-color: white;
+    position: relative;
 }
 
 .card .card-media {

--- a/src/Umbraco.Cms.12.x/wwwroot/css/myblockgridlayout.css
+++ b/src/Umbraco.Cms.12.x/wwwroot/css/myblockgridlayout.css
@@ -94,6 +94,14 @@
     }
 }
 
+.blockelement__draggable-element {
+    height: 100%;
+}
+
+.blockelement__draggable-element > div:first-of-type {
+    height: 100%;
+}
+
 section {
     padding: var(--section-padding, 60px 0);
 }
@@ -128,20 +136,20 @@ h2 {
 
 /**umb_name:H3*/
 h3 {
-	font-size: 30px;
-	font-weight: 300;
-	line-height: 1.2;
-	margin:0;
-	color: inherit;
+    font-size: 30px;
+    font-weight: 300;
+    line-height: 1.2;
+    margin:0;
+    color: inherit;
 }
 
 /**umb_name:H4*/
 h4 {
-	font-size: 21px;
-	font-weight: 300;
-	line-height: 1.2;
-	margin:0;
-	color: inherit;
+    font-size: 21px;
+    font-weight: 300;
+    line-height: 1.2;
+    margin:0;
+    color: inherit;
 }
 
 
@@ -184,7 +192,7 @@ p.lead-paragraph {
 
 /** Hero */
 
-.umb-block-grid__layout-item[data-content-element-type-alias="heroBlock"] .umb-block-grid__area-container, 
+.umb-block-grid__layout-item[data-content-element-type-alias="heroBlock"] .umb-block-grid__area-container,
 .umb-block-grid__layout-item[data-content-element-type-alias="heroBlock"] .umb-block-grid__block--view::part(area-container) {
     padding: 0;
 }
@@ -264,7 +272,7 @@ p.lead-paragraph {
     padding: var(--my-container-padding);
     margin-left: auto;
     margin-right: auto;
-    
+
     display: grid;
     grid-template-columns: 1fr 1fr 1fr 1fr;
     grid-auto-flow: row;
@@ -312,6 +320,7 @@ p.lead-paragraph {
     height: 100%;
     color: black;
     background-color: white;
+    position: relative;
 }
 
 .card .card-media {

--- a/src/Umbraco.Cms.13.x/wwwroot/css/myblockgridlayout.css
+++ b/src/Umbraco.Cms.13.x/wwwroot/css/myblockgridlayout.css
@@ -94,6 +94,14 @@
     }
 }
 
+.blockelement__draggable-element {
+    height: 100%;
+}
+
+.blockelement__draggable-element > div:first-of-type {
+    height: 100%;
+}
+
 section {
     padding: var(--section-padding, 60px 0);
 }
@@ -312,6 +320,7 @@ p.lead-paragraph {
     height: 100%;
     color: black;
     background-color: white;
+    position: relative;
 }
 
 .card .card-media {


### PR DESCRIPTION
# Description
BlockPreview output should be as close as possible to the Angular/WebComponent equivalent.

# Issue
Based off of the [source repo](https://github.com/umbraco/Umbraco.BlockGrid.Example.Website), BlockPreview should ideally provide a 1:1 replication.

Umbraco 13 Angular View:
![image](https://github.com/user-attachments/assets/9778cccc-83cc-44aa-b783-2209fa930117)

Umbraco 13 BlockPreview View:
![image](https://github.com/user-attachments/assets/e904cdba-0da8-4e08-9dd3-4b3c3eaaafc4)

Umbraco 13 BlockPreview View with Fix:
![image](https://github.com/user-attachments/assets/a84a7c36-ba89-4b77-9d40-49df1ecd6f0c)

# Note
I have also added position:relative to the `.card` class as this was missing from the original styling. In Umbraco.BlockGrid.Example.Website project, the card is a `button` element rather than a `div` which contains `position: relative`.

# Fix
Applied styling to the container element `.blockelement__draggable-element` produced by BlockPreview to grow to the full height of the area.

``` css
.blockelement__draggable-element {
    height: 100%;
}

.blockelement__draggable-element > div {
    height: 100%;
}
```

This fix could potentially sit in `/wwwroot/App_Plugins/Umbraco.Community.BlockPreview/views/block-preview.html`, however I decided against an inline style fix as I avoid using them when possible and in the event people have worked around this in their own styling I did not want to force a change on their website styling.
