### PR TITLE
fix: Content Picker not returning a valid element

### DIFF
--- a/src/Umbraco.Community.BlockPreview/Services/BlockPreviewService.cs
+++ b/src/Umbraco.Community.BlockPreview/Services/BlockPreviewService.cs
@@ -248,6 +248,24 @@ namespace Umbraco.Community.BlockPreview.Services
 
         private IPublishedElement? ConvertToElement(BlockItemData data, bool throwOnError)
         {
+            var properties = data.RawPropertyValues;
+            
+            // Check each property, if a property is just a guid, convert to UDI
+            for (var i = 0; i < properties.Count; i++)
+            {
+                var key = properties.Keys.ElementAt(i);
+                var value = properties[key];
+                var propertyAsString = value?.ToString();
+            
+                // Continue if empty, contains UDI or if it's not a guid.
+                if (propertyAsString == null) continue;
+                if (propertyAsString.Contains("umb://")) continue;
+                if (!Guid.TryParse(propertyAsString, out var guid)) continue;
+            
+                // Convert guid to UDI and set property value
+                properties[key] = "umb://element/" + guid;
+            }
+            
             var element = _blockEditorConverter.ConvertToElement(data, PropertyCacheLevel.None, throwOnError);
             if (element == null && throwOnError)
                 throw new InvalidOperationException($"Unable to find Element {data?.ContentTypeAlias}");


### PR DESCRIPTION
# Issue
Content Picker not returning a valid element in preview.

## Cause
This was being caused by Umbraco 14 expecting a UDI while the Block Preview preview/grid API end-point was only receiving a GUID.

Example:
Below is the data currently being passed to the API end-point:
```
  "contentData": [
    {
      "contentTypeKey": "6de88d63-fb9e-479a-a0f2-bb898c2bbadc",
      "udi": "umb://element/97cae2cefdd648b9b80ec911e04aa248",
      "title": "Test",
      "manuallyPicked": "aa88e78d-4943-411b-a933-f1d2709c4785",
      "multinodeTreepickerTags": [
        {
          "key": "494616e3-0ec9-47db-8398-dfdc6b01ee95",
          "mediaKey": "65a066c2-b30d-497b-a53c-968e3f9a20d1",
          "mediaTypeAlias": "Image",
          "crops": [],
          "focalPoint": null
        }
      ]
    }
  ],
```

Below is what was being expected by Umbraco:
```
  "contentData": [
    {
      "contentTypeKey": "6de88d63-fb9e-479a-a0f2-bb898c2bbadc",
      "udi": "umb://element/97cae2cefdd648b9b80ec911e04aa248",
      "title": "Test",
      "manuallyPicked": "umb://element/aa88e78d-4943-411b-a933-f1d2709c4785",
      "multinodeTreepickerTags": [
        {
          "key": "494616e3-0ec9-47db-8398-dfdc6b01ee95",
          "mediaKey": "65a066c2-b30d-497b-a53c-968e3f9a20d1",
          "mediaTypeAlias": "Image",
          "crops": [],
          "focalPoint": null
        }
      ]
    }
  ],
```

This was causing the view to receive a null property:
![image](https://github.com/user-attachments/assets/b9fde1ca-b4bb-42c4-87d5-7e7a0173872b)

Once the fix was applied, it was working again as expected:
![image](https://github.com/user-attachments/assets/dba8d133-1492-47f0-92bc-75131c4264a1)

## Note
While another developer has noted that `umb://document/` is expected, I refrained from using that and used `umb://element/` instead, which also works and I imagine has less chance of breaking another type if there is another type that only sends a GUID across and does not support the `umb://document/` UDI format.

I have tested this with as many content types as possible and have not had any issues, however @rickbutterfield I would request that you test this too as you would be more aware of potential clashes and edge cases due to how this fix is being applied. If you feel this should be fixed elsewhere, I am happy to assist in doing so.