### PR TITLE
Fix incorrect blockData null/empty check

### DIFF
--- a/src/Umbraco.Community.BlockPreview/Services/BlockPreviewService.cs
+++ b/src/Umbraco.Community.BlockPreview/Services/BlockPreviewService.cs
@@ -399,7 +399,7 @@ namespace Umbraco.Community.BlockPreview.Services
 
         private void FormatBlockData(List<BlockItemData>? blockData)
         {
-            if (blockData == null || blockData.Count != 0)
+            if (blockData == null || blockData.Count == 0)
                 return;
 
             foreach (var contentData in blockData)


### PR DESCRIPTION
Previously, the condition checked:

    if (blockData == null || blockData.Count != 0)

This was incorrect, because it should be checking for 0 - now the preview won't render things such as contentpickers. 

Updated to:

    if (blockData == null || blockData.Count == 0)

Now the condition properly handles both null and empty blockData.