### PR TITLE
Fixes #144 by using consumeContext over getContext

### DIFF
--- a/src/Umbraco.Community.BlockPreview.UI/src/blockEditor/block-grid-preview.custom-view.element.ts
+++ b/src/Umbraco.Community.BlockPreview.UI/src/blockEditor/block-grid-preview.custom-view.element.ts
@@ -148,21 +148,24 @@ export class BlockGridPreviewCustomView
     }
 
     async #observeDocumentWorkspace() {
-        this.getContext(UMB_DOCUMENT_WORKSPACE_CONTEXT).then((context) => {
-            if (context) {
-                this.#documentWorkspaceContext = context;
-                this.observe(
-                    observeMultiple([context.unique, context.contentTypeUnique]),
-                    async ([unique, documentTypeUnique]) => {
-                        this._blockContext.unique = unique?.toString() ?? '';
-                        this.#blockPreviewContext?.setUnique(this._blockContext.unique);
+        
+        this.consumeContext(UMB_DOCUMENT_WORKSPACE_CONTEXT,(context)=>{
+            if(!context)
+                return;
 
-                        this._blockContext.documentTypeUnique = documentTypeUnique ?? '';
-                        this.#blockPreviewContext?.setDocumentTypeUnique(this._blockContext.documentTypeUnique);
-                        this.#observeBlockValue();
-                    }
-                );
-            }
+            this.#documentWorkspaceContext = context;
+            this.observe(
+                observeMultiple([context.unique, context.contentTypeUnique]),
+                async ([unique, documentTypeUnique]) => {
+                    this._blockContext.unique = unique?.toString() ?? '';
+                    this.#blockPreviewContext?.setUnique(this._blockContext.unique);
+
+                    this._blockContext.documentTypeUnique = documentTypeUnique ?? '';
+                    this.#blockPreviewContext?.setDocumentTypeUnique(this._blockContext.documentTypeUnique);
+                    this.#observeBlockValue();
+                }
+            );
+            
         });
 
         if (this.#documentWorkspaceContext == null && this.#blockPreviewContext != null && this._blockContext.unique == '') {


### PR DESCRIPTION
Fixes this: https://github.com/rickbutterfield/BlockPreview/issues/144

By using `consumeContext` over `getContext`.

After this there are no more errors in the console when dragging

![umb-no-rejection](https://github.com/user-attachments/assets/63ffae5c-e7d9-4d70-a99f-35509b09ad04)
