### PR TITLE
feat: raise event on when displaying block preview

### DIFF
--- a/src/Umbraco.Community.BlockPreview.UI/src/blockEditor/block-grid-preview.custom-view.element.ts
+++ b/src/Umbraco.Community.BlockPreview.UI/src/blockEditor/block-grid-preview.custom-view.element.ts
@@ -332,6 +332,13 @@ export class BlockGridPreviewCustomView
             if (data) {
                 this._htmlMarkup = data ?? '';
                 this._isLoading = false;
+
+                document.body.dispatchEvent(new CustomEvent('umb-block-preview-rendered', {
+                    detail: {
+                        host: this,
+                        html: this._htmlMarkup
+                    }
+                }));
             }
             else if (UmbApiError.isUmbApiError(error)) {
                 this._error = error.message;

--- a/src/Umbraco.Community.BlockPreview.UI/src/blockEditor/block-list-preview.custom-view.element.ts
+++ b/src/Umbraco.Community.BlockPreview.UI/src/blockEditor/block-list-preview.custom-view.element.ts
@@ -300,6 +300,12 @@ export class BlockListPreviewCustomView
             if (data) {
                 this._htmlMarkup = data ?? '';
                 this._isLoading = false;
+                document.body.dispatchEvent(new CustomEvent('umb-block-list-preview-rendered', {
+                    detail: {
+                        host: this,
+                        html: this._htmlMarkup
+                    }
+                }));
             }
             else if (UmbApiError.isUmbApiError(error)) {
                 this._error = error.message;

--- a/src/Umbraco.Community.BlockPreview.UI/src/blockEditor/rich-text-preview.custom-view.element.ts
+++ b/src/Umbraco.Community.BlockPreview.UI/src/blockEditor/rich-text-preview.custom-view.element.ts
@@ -255,6 +255,12 @@ export class RichTextPreviewCustomView
             if (data) {
                 this._htmlMarkup = data ?? '';
                 this._isLoading = false;
+                document.body.dispatchEvent(new CustomEvent('umb-block-rte-preview-rendered', {
+                    detail: {
+                        host: this,
+                        html: this._htmlMarkup
+                    }
+                }));
             }
             else if (UmbApiError.isUmbApiError(error)) {
                 this._error = error.message;


### PR DESCRIPTION
When using a themed "Section" block that contains child blocks in an area, the theme CSS class applied to the Section is not propagated to its child blocks in the Umbraco backoffice. This is due to CSS scope isolation caused by web components and their shadow DOM boundaries, which prevent theme styles from cascading naturally to nested blocks.

This event allows us to react in javascript to the event and copy the section theme to the blocks inside the section.