### PR TITLE
Adds cachebusting query param to assets.js

### DIFF
--- a/src/Umbraco.Community.BlockPreview.UI/public/umbraco-package.json
+++ b/src/Umbraco.Community.BlockPreview.UI/public/umbraco-package.json
@@ -9,7 +9,7 @@
       "name": "Umbraco.Community.BlockPreview.EntryPoint",
       "alias": "Umbraco.Community.BlockPreview.EntryPoint",
       "type": "backofficeEntryPoint",
-      "js": "/App_Plugins/Umbraco.Community.BlockPreview/assets.js"
+      "js": "/App_Plugins/Umbraco.Community.BlockPreview/assets.js?v=5.0.0"
     }
   ]
 }


### PR DESCRIPTION
To prevent browsers clinging on to old versions of assets.js, I've added a querystring parameter containing the version number.

Should be updated alongside the version number, when releasing new versions.