### PR TITLE
fix: Remove unreliable IsBackOfficeRequest check from IsBlockPreviewRequest

### DIFF
--- a/src/Umbraco.Community.BlockPreview/Extensions/HttpRequestExtensions.cs
+++ b/src/Umbraco.Community.BlockPreview/Extensions/HttpRequestExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Umbraco.Community.BlockPreview.Controllers;
-using Umbraco.Extensions;
 
 namespace Umbraco.Community.BlockPreview.Extensions
 {
@@ -18,9 +17,6 @@ namespace Umbraco.Community.BlockPreview.Extensions
         {
             var httpContext = request.HttpContext;
 
-            // We're always going to be coming from the back office so let's check that
-            bool isBackOffice = request.IsBackOfficeRequest();
-
             string requestControllerName = (string)httpContext.Request.RouteValues["controller"]! + "Controller";
 
             bool requestControllerMatches = requestControllerName.Equals(nameof(BlockPreviewApiController));
@@ -28,9 +24,7 @@ namespace Umbraco.Community.BlockPreview.Extensions
             bool isBlockListPreview = httpContext.Request.RouteValues["action"]!.Equals(nameof(BlockPreviewApiController.PreviewListBlock));
             bool isRichTextPreview = httpContext.Request.RouteValues["action"]!.Equals(nameof(BlockPreviewApiController.PreviewRichTextMarkup));
 
-            bool isBlockPreviewController = requestControllerMatches && (isBlockGridPreview || isBlockListPreview || isRichTextPreview);
-
-            return isBackOffice || isBlockPreviewController;
+            return requestControllerMatches && (isBlockGridPreview || isBlockListPreview || isRichTextPreview);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Removes the `IsBackOfficeRequest()` check from `IsBlockPreviewRequest()` which was causing false positives on frontend pages with URLs starting with `/umbraco` (e.g. `/umbraco-explained`)
- The `isBlockPreviewController` check alone is sufficient — it verifies the exact controller and action match
- Root cause: Umbraco's `IsBackOfficeRequest()` heuristic doesn't recognise custom backoffice API routes like `/umbraco/block-preview/api/...`, which led to a previous `&&` → `||` workaround (5b4fc53) that introduced the bug

Fixes #239

## Test plan
- [ ] Create a page with a URL starting with `/umbraco` (e.g. `/umbraco-explained`)
- [ ] Add block grid/list content using `IsBlockPreviewRequest()` to conditionally render
- [ ] Verify the frontend shows frontend rendering, not backend preview rendering
- [ ] Verify the backoffice still shows block previews correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)