### PR TITLE
fix: Use single configured language as culture fallback for block previews

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,37 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(dir:*)",
+      "Bash(do)",
+      "Bash(done)",
+      "Bash(echo:*)",
+      "Bash(find:*)",
+      "Bash(for:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(gh pr view:*)",
+      "Bash(git log:*)",
+      "Bash(grep:*)",
+      "Bash(npm run build:*)",
+      "Bash(npm run check:*)",
+      "Bash(npm run compile:*)",
+      "Bash(npm run lint:*)",
+      "Bash(npm run typecheck:*)",
+      "Bash(npm run:*)",
+      "Bash(npx eslint:*)",
+      "Bash(npx tsc:*)",
+      "Bash(tree:*)",
+      "Bash(gh issue view:*)",
+      "Bash(npm test:*)",
+      "mcp__umbraco__create*",
+      "mcp__umbraco__get*",
+      "mcp__playwright__browser_click",
+      "mcp__playwright__browser_type",
+      "mcp__playwright__browser_wait_for"
+    ]
+  },
+  "enableAllProjectMcpServers": true,
+  "enabledMcpjsonServers": [
+    "umbraco-cms",
+    "playwright"
+  ]
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,20 @@
+{
+  "mcpServers": {
+    "umbraco-cms": {
+      "command": "cmd",
+      "args": [
+        "/c",
+        "npx",
+        "@umbraco-cms/mcp-dev@17"
+      ]
+    },
+    "playwright": {
+      "command": "cmd",
+      "args": [
+        "/c",
+        "npx",
+        "@playwright/mcp@latest"
+      ]
+    }
+  }
+}

--- a/MCP.md
+++ b/MCP.md
@@ -1,0 +1,122 @@
+# MCP (Model Context Protocol) Setup
+
+This repository includes configuration for [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) servers, enabling AI tooling integration for Umbraco CMS development workflows.
+
+## Overview
+
+MCP allows AI assistants (like Claude) to interact with external tools and services. This repository configures two MCP servers:
+
+| Server | Purpose | Package |
+|--------|---------|---------|
+| **umbraco-cms** | Manage Umbraco content types, documents, and media | `@umbraco-cms/mcp-dev@17` |
+| **playwright** | Browser automation for testing and debugging | `@playwright/mcp@latest` |
+
+## Quick Start
+
+### 1. Start Umbraco Locally
+
+Ensure your local Umbraco instance is running at `https://localhost:44369` (or update the URL to match your test site configuration).
+
+### 2. Configure the OAuth Client in Umbraco
+
+The Umbraco MCP server requires an OAuth client configured in your Umbraco instance:
+
+- **Client ID**: `umbraco-back-office-mcp`
+- **Client Secret**: A secure secret of your choice
+- **Grant Type**: Client Credentials
+
+The MCP server will prompt for these credentials when it connects. Set the following environment variables if you want to avoid prompts:
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `UMBRACO_CLIENT_ID` | OAuth client ID configured in Umbraco | `umbraco-back-office-mcp` |
+| `UMBRACO_CLIENT_SECRET` | OAuth client secret (keep secure!) | `your-secure-secret` |
+| `UMBRACO_BASE_URL` | URL of your local Umbraco instance | `https://localhost:44369` |
+| `NODE_TLS_REJECT_UNAUTHORIZED` | Set to `0` for self-signed certificates (local dev only) | `0` |
+| `UMBRACO_INCLUDE_TOOL_COLLECTIONS` | Comma-separated list of tool collections to enable | `data-type,document-type,document` |
+
+### Tool Collections
+
+The `UMBRACO_INCLUDE_TOOL_COLLECTIONS` variable controls which Umbraco MCP tools are available:
+
+- `data-type` - Manage data types (property editors)
+- `document-type` - Manage document types (content types)
+- `document` - Manage content/documents
+- `media-type` - Manage media types
+- `media` - Manage media items
+
+## Security Considerations
+
+> **Warning**: This configuration is for **local development only**.
+
+### Self-Signed Certificates
+
+`NODE_TLS_REJECT_UNAUTHORIZED=0` disables SSL certificate validation. This is necessary for self-signed certificates in local development but:
+
+- **Never use in production**
+- Affects all HTTPS connections made by Node.js processes
+- Consider trusting your local development certificate instead
+
+### Client Secrets
+
+- Never commit real secrets to source control
+- Use strong, unique secrets even in development
+
+## File Structure
+
+```
+BlockPreview-v5/
+├── .mcp.json              # MCP server configuration
+├── .claude/
+│   ├── settings.json      # Shared Claude AI permissions (committed)
+│   └── settings.local.json # Local Claude overrides (gitignored)
+└── MCP.md                 # This documentation (you are here)
+```
+
+## Claude AI Permissions
+
+The `.claude/settings.json` file configures which MCP tools Claude can use automatically without prompting. This is shared across the team for consistent developer experience.
+
+### Customizing Permissions Locally
+
+Create `.claude/settings.local.json` to override permissions for your environment:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "mcp__umbraco__get-all-document-types"
+    ]
+  }
+}
+```
+
+## Troubleshooting
+
+### "Connection refused" errors
+
+- Ensure Umbraco is running at the configured URL
+- Check that the port matches your local setup
+
+### "Unauthorized" errors
+
+- Verify the OAuth client is configured in Umbraco
+- Check that your client ID and secret match
+- Ensure the client has appropriate permissions
+
+### "Certificate" errors
+
+- For local development, set `NODE_TLS_REJECT_UNAUTHORIZED=0`
+- Alternatively, trust your local development certificate
+
+### MCP server not starting
+
+- Ensure Node.js is installed (v22+ recommended)
+- Run `npx @umbraco-cms/mcp-dev@17 --help` to verify the package works
+
+## Further Reading
+
+- [Model Context Protocol Documentation](https://modelcontextprotocol.io/)
+- [Umbraco MCP Package](https://www.npmjs.com/package/@umbraco-cms/mcp-dev)
+- [Playwright MCP](https://www.npmjs.com/package/@playwright/mcp)
+- [Claude Code Documentation](https://docs.anthropic.com/claude-code)

--- a/src/Umbraco.Community.BlockPreview/Controllers/BlockPreviewApiController.cs
+++ b/src/Umbraco.Community.BlockPreview/Controllers/BlockPreviewApiController.cs
@@ -537,12 +537,22 @@ namespace Umbraco.Community.BlockPreview.Controllers
 
         private async Task<string?> GetCurrentCulture(string? culture, IPublishedContent? content = null)
         {
-            var currentCulture = string.IsNullOrWhiteSpace(culture)
-                ? content?.GetCultureFromDomains()
+            var currentCulture = string.IsNullOrWhiteSpace(culture) || culture == "undefined"
+                ? null
                 : culture;
 
-            if (string.IsNullOrEmpty(currentCulture) || culture == "undefined")
-                currentCulture = await _languageService.GetDefaultIsoCodeAsync();
+            // Try domain-based culture from the content
+            currentCulture ??= content?.GetCultureFromDomains();
+
+            // If only one language is configured, use it regardless of default flag
+            if (string.IsNullOrEmpty(currentCulture))
+            {
+                var allLanguages = await _languageService.GetAllAsync();
+                var languages = allLanguages.ToList();
+                currentCulture = languages.Count == 1
+                    ? languages[0].IsoCode
+                    : await _languageService.GetDefaultIsoCodeAsync();
+            }
 
             _contextCultureService.SetCulture(currentCulture);
 


### PR DESCRIPTION
## Summary
- Fixes block previews always using "en-US" culture on single-language non-English sites
- For invariant content, the frontend sends no culture. The backend previously fell back to `GetDefaultIsoCodeAsync()`, which returns the DB default language (typically "en-US" from installation) even when the site only has a different language configured
- The culture fallback chain is now:
  1. Frontend culture (from variant editing context)
  2. Domain culture (`GetCultureFromDomains()`)
  3. Single language — if only one language is configured, use it directly
  4. Default language (`GetDefaultIsoCodeAsync()`) for multi-language sites
- Also fixes the `"undefined"` string check to be evaluated upfront instead of after the domain fallback

Fixes #234

## Test plan
- [ ] Configure a single-language site with a non-English language (e.g. "nl")
- [ ] Add block grid/list content using `Umbraco.GetDictionaryValue()` or culture-dependent formatting
- [ ] Verify block previews render with the correct culture (not "en-US")
- [ ] On a multi-language site, verify editing variant content still uses the correct culture per variant
- [ ] Verify invariant properties on multi-language sites fall back to the default language

🤖 Generated with [Claude Code](https://claude.com/claude-code)