### PR TITLE
Add VS Code configuration for development tasks and debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,29 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": ".NET Core Launch (TestSite)",
+      "type": "coreclr",
+      "request": "launch",
+      "program": "dotnet",
+      "args": ["run"],
+      "cwd": "${workspaceFolder}/examples/Umbraco.Community.BlockPreview.TestSite",
+      "stopAtEntry": false,
+      "requireExactSource": false,
+      "postDebugTask": "kill-test-site",
+      "serverReadyAction": {
+        "action": "openExternally",
+        "pattern": "\\bNow listening on:\\s+(https?://\\S+)"
+      },
+      "env": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    {
+      "name": ".NET Core Attach",
+      "type": "coreclr",
+      "request": "attach",
+      "processId": "${command:pickProcess}"
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "dotnet.defaultSolution": "src/Umbraco.Community.BlockPreview.sln"
+  "dotnet.defaultSolution": "Umbraco.Community.BlockPreview.sln"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,87 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Build",
+      "detail": "Builds the client and solution",
+      "promptOnClose": true,
+      "group": "build",
+      "dependsOn": ["Client Build", "Dotnet build"],
+      "problemMatcher": []
+    },
+    {
+      "label": "Client Install",
+      "detail": "Install npm packages for BlockPreview.UI",
+      "promptOnClose": true,
+      "type": "npm",
+      "script": "install",
+      "path": "src/Umbraco.Community.BlockPreview.UI/",
+      "problemMatcher": []
+    },
+    {
+      "label": "Client Build",
+      "detail": "Runs npm run build for BlockPreview.UI",
+      "promptOnClose": true,
+      "group": "build",
+      "type": "npm",
+      "script": "build",
+      "path": "src/Umbraco.Community.BlockPreview.UI/",
+      "problemMatcher": []
+    },
+    {
+      "label": "Client Watch",
+      "detail": "Runs npm run dev for BlockPreview.UI",
+      "promptOnClose": true,
+      "group": "build",
+      "type": "npm",
+      "script": "dev",
+      "path": "src/Umbraco.Community.BlockPreview.UI/",
+      "problemMatcher": []
+    },
+    {
+      "label": "Dotnet build",
+      "detail": "Dotnet build of solution",
+      "promptOnClose": true,
+      "group": "build",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "build",
+        "${workspaceFolder}/Umbraco.Community.BlockPreview.sln",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "Dotnet watch",
+      "detail": "Dotnet run and watch of TestSite",
+      "promptOnClose": true,
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "watch",
+        "run",
+        "--project",
+        "${workspaceFolder}/examples/Umbraco.Community.BlockPreview.TestSite/Umbraco.Community.BlockPreview.TestSite.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "kill-test-site",
+      "type": "shell",
+      "problemMatcher": [],
+      "osx": {
+        "command": "pkill -f Umbraco.Community.BlockPreview.TestSite"
+      },
+      "linux": {
+        "command": "pkill -f Umbraco.Community.BlockPreview.TestSite"
+      },
+      "windows": {
+        "command": "taskkill /IM Umbraco.Community.BlockPreview.TestSite.exe /F"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
This PR adds VS Code workspace configuration files to streamline the development experience for contributors working on the BlockPreview project.

## Key Changes
- **Added `.vscode/tasks.json`**: Defines build and development tasks including:
  - Client-side npm tasks (install, build, watch) for the BlockPreview.UI project
  - .NET build task for the solution
  - .NET watch task for running the TestSite project with hot reload
  - Platform-specific task to kill the TestSite process (Windows, macOS, Linux)
  - Composite "Build" task that runs both client and .NET builds

- **Added `.vscode/launch.json`**: Provides debugging configurations:
  - .NET Core launch configuration for the TestSite project with automatic browser opening
  - .NET Core attach configuration for debugging running processes
  - Automatic cleanup of the TestSite process after debugging stops

- **Updated `.vscode/settings.json`**: Fixed the default solution path from `src/Umbraco.Community.BlockPreview.sln` to `Umbraco.Community.BlockPreview.sln` to match the actual project structure

## Benefits
These configurations enable developers to:
- Build both client and server components with a single command
- Debug the TestSite application directly from VS Code
- Run development servers with file watching for rapid iteration
- Have a consistent development environment across team members

https://claude.ai/code/session_015JoPQr4bPMG8ZTb567haCd