### PR TITLE
docs: Add v4 release history to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## v4 (Umbraco 14-16)
+## v4 (Umbraco 16)
 
 ## [4.2.2] - 2026-02-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,71 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## v4 (Umbraco 14-16)
+
+## [4.2.2] - 2026-02-12
+
+### Fixed
+- Fix concurrent block preview rendering producing empty strings or ObjectDisposedException by caching view paths instead of ViewEngineResult objects
+
+## [4.2.1] - 2026-02-12
+
+### Fixed
+- Resolve ambiguous constructor error in BlockPreviewService
+
+## [4.2.0] - 2026-02-12
+
+### Added
+- Sort mode property action for block grid
+
+### Fixed
+- Stop data-block-preview-link clicks from bubbling to parent blocks
+- Block non-edit action bar clicks from propagating to parent block
+- Return 200 OK instead of 404 when no stylesheets are configured
+- Use single configured language as culture fallback for block previews
+- Remove unreliable IsBackOfficeRequest check from IsBlockPreviewRequest
+- Use generic CMS property editor conversion and fix preview errors
+
+### Changed
+- Use UMB_CONTENT_WORKSPACE_CONTEXT for broader workspace compatibility
+- Extract services from BlockPreviewService (IBlockModelFactory, IBlockViewRenderer, IBlockDataConverter)
+- Cached view resolution for improved performance
+
+## [4.1.1] - 2026-01-23
+
+### Fixed
+- Fix RTE blocks stylesheet loading to match BlockGrid/BlockList behavior
+- Stop unnecessary calls to stylesheet API when `documentTypeUnique` is undefined ([#226](https://github.com/rickbutterfield/BlockPreview/pull/226))
+
+## [4.1.0] - 2026-01-22
+
+### Added
+- Add IBlockPreviewResponseEnricher
+- Add IgnoredContentTypes support to BlockPreview config for excluding element types from previews
+- Add support for multiple stylesheets per block type
+- Add async CreateViewDataAsync method with sync fallback
+- Cache busting for App_Plugins
+
+### Changed
+- Reinstate sort mode for v16
+
+### Fixed
+- Fixes #220
+- Workaround for empty unique variable editing blockgrid / blocklist
+- Fix for #179
+
+## [4.0.7] - 2025-11-28
+
+### Fixed
+- Resolve #179 for v4
+
+## [4.0.6] - 2025-11-27
+
+### Changed
+- Project restructure
+
+---
+
 **Full Changelog**: https://github.com/rickbutterfield/BlockPreview/releases
 
 [5.3.2]: https://github.com/rickbutterfield/BlockPreview/compare/release-5.3.1...release-5.3.2
@@ -89,3 +154,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [5.2.0]: https://github.com/rickbutterfield/BlockPreview/compare/release-5.1.0...release-5.2.0
 [5.1.0]: https://github.com/rickbutterfield/BlockPreview/compare/release-5.0.0...release-5.1.0
 [5.0.0]: https://github.com/rickbutterfield/BlockPreview/compare/v4.0.5...release-5.0.0
+[4.2.2]: https://github.com/rickbutterfield/BlockPreview/compare/release-4.2.1...release-4.2.2
+[4.2.1]: https://github.com/rickbutterfield/BlockPreview/compare/release-4.2.0...release-4.2.1
+[4.2.0]: https://github.com/rickbutterfield/BlockPreview/compare/release-4.1.1...release-4.2.0
+[4.1.1]: https://github.com/rickbutterfield/BlockPreview/compare/release-4.1.0...release-4.1.1
+[4.1.0]: https://github.com/rickbutterfield/BlockPreview/compare/release-4.0.7...release-4.1.0
+[4.0.7]: https://github.com/rickbutterfield/BlockPreview/compare/release-4.0.6...release-4.0.7
+[4.0.6]: https://github.com/rickbutterfield/BlockPreview/compare/v4.0.5...release-4.0.6


### PR DESCRIPTION
Add changelog entries for all v4 releases (4.0.6 through 4.2.2) based on
release tags and commit history from v4/main branch. Includes comparison
links for all v4 versions.

https://claude.ai/code/session_01RZkGdHQogjcosPnXZoKj9V