### PR TITLE
fix: Make AddInternal extension method internal

### DIFF
--- a/src/Umbraco.Community.BlockPreview/Extensions/BlockPreviewUmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Community.BlockPreview/Extensions/BlockPreviewUmbracoBuilderExtensions.cs
@@ -32,7 +32,7 @@ namespace Umbraco.Community.BlockPreview.Extensions
         /// <param name="builder">The Umbraco builder.</param>
         /// <param name="configure">The optional configuration action.</param>
         /// <returns>The Umbraco builder.</returns>
-        public static IUmbracoBuilder AddInternal(this IUmbracoBuilder builder,
+        internal static IUmbracoBuilder AddInternal(this IUmbracoBuilder builder,
             Action<OptionsBuilder<BlockPreviewOptions>>? configure = null)
         {
             ArgumentNullException.ThrowIfNull(builder);


### PR DESCRIPTION
## Summary

Make the AddInternal extension method internal to prevent accidental public API exposure.

## Based On
This PR addresses findings from [BEST-PRACTICES-REVIEW.md](https://github.com/rickbutterfield/BlockPreview/blob/v5/main/BEST-PRACTICES-REVIEW.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)