### PR TITLE
refactor: Switch notification handlers to INotificationAsyncHandler

### DIFF
--- a/src/Umbraco.Community.BlockPreview/BlockPreviewComposer.cs
+++ b/src/Umbraco.Community.BlockPreview/BlockPreviewComposer.cs
@@ -23,8 +23,8 @@ namespace Umbraco.Community.BlockPreview
 
             builder.Services.ConfigureOptions<ConfigureSwaggerGenOptions>();
 
-            builder.AddNotificationHandler<DataTypeSavedNotification, DataTypeSavedNotificationHandler>();
-            builder.AddNotificationHandler<ContentTypeSavedNotification, ContentTypeSavedNotificationHandler>();
+            builder.AddNotificationAsyncHandler<DataTypeSavedNotification, DataTypeSavedNotificationHandler>();
+            builder.AddNotificationAsyncHandler<ContentTypeSavedNotification, ContentTypeSavedNotificationHandler>();
 
             builder.Services.AddScoped<IViewComponentHelperWrapper>(sp =>
             {

--- a/src/Umbraco.Community.BlockPreview/NotificationHandlers/ContentTypeSavedNotificationHandler.cs
+++ b/src/Umbraco.Community.BlockPreview/NotificationHandlers/ContentTypeSavedNotificationHandler.cs
@@ -1,8 +1,5 @@
-﻿using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Core.Cache;
-using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Events;
-using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Community.BlockPreview.Interfaces;
 using Umbraco.Extensions;
@@ -12,7 +9,7 @@ namespace Umbraco.Community.BlockPreview.NotificationHandlers
     /// <summary>
     /// Handles content type saved notifications to clear related caches.
     /// </summary>
-    public class ContentTypeSavedNotificationHandler : INotificationHandler<ContentTypeSavedNotification>
+    public class ContentTypeSavedNotificationHandler : INotificationAsyncHandler<ContentTypeSavedNotification>
     {
         private readonly IAppPolicyCache _runtimeCache;
         private readonly IBlockPreviewViewResolver _viewResolver;
@@ -29,23 +26,14 @@ namespace Umbraco.Community.BlockPreview.NotificationHandlers
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ContentTypeSavedNotificationHandler"/> class.
-        /// </summary>
-        /// <param name="appCaches">The application caches.</param>
-        [Obsolete("Use the constructor that accepts IBlockPreviewViewResolver.")]
-        public ContentTypeSavedNotificationHandler(AppCaches appCaches)
-            : this(appCaches, StaticServiceProvider.Instance.GetRequiredService<IBlockPreviewViewResolver>())
-        {
-        }
-
-        /// <summary>
         /// Handles the content type saved notification.
         /// </summary>
         /// <param name="notification">The notification.</param>
-        public void Handle(ContentTypeSavedNotification notification)
+        /// <param name="cancellationToken">The cancellation token.</param>
+        public Task HandleAsync(ContentTypeSavedNotification notification, CancellationToken cancellationToken)
         {
             if (notification.SavedEntities == null || !notification.SavedEntities.Any())
-                return;
+                return Task.CompletedTask;
 
             foreach (var savedContentType in notification.SavedEntities)
             {
@@ -63,6 +51,8 @@ namespace Umbraco.Community.BlockPreview.NotificationHandlers
                 if (savedContentType.IsElement)
                     _viewResolver.ClearCacheForAlias(savedContentType.Alias);
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/Umbraco.Community.BlockPreview/NotificationHandlers/DataTypeSavedNotificationHandler.cs
+++ b/src/Umbraco.Community.BlockPreview/NotificationHandlers/DataTypeSavedNotificationHandler.cs
@@ -1,21 +1,18 @@
-﻿using Umbraco.Cms.Core.Cache;
-using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Events;
-using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Extensions;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Umbraco.Community.BlockPreview.NotificationHandlers
 {
     /// <summary>
     /// Handles data type saved notifications to clear related caches.
     /// </summary>
-    public class DataTypeSavedNotificationHandler : INotificationHandler<DataTypeSavedNotification>
+    public class DataTypeSavedNotificationHandler : INotificationAsyncHandler<DataTypeSavedNotification>
     {
         private readonly IAppPolicyCache _runtimeCache;
-        private readonly IContentTypeService? _contentTypeService;
+        private readonly IContentTypeService _contentTypeService;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DataTypeSavedNotificationHandler"/> class.
@@ -29,23 +26,14 @@ namespace Umbraco.Community.BlockPreview.NotificationHandlers
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="DataTypeSavedNotificationHandler"/> class.
-        /// </summary>
-        /// <param name="appCaches">The application caches.</param>
-        [Obsolete("Use the constructor that accepts IContentTypeService for cascading cache invalidation.")]
-        public DataTypeSavedNotificationHandler(AppCaches appCaches)
-            : this(appCaches, StaticServiceProvider.Instance.GetRequiredService<IContentTypeService>())
-        {
-        }
-
-        /// <summary>
         /// Handles the data type saved notification.
         /// </summary>
         /// <param name="notification">The notification.</param>
-        public void Handle(DataTypeSavedNotification notification)
+        /// <param name="cancellationToken">The cancellation token.</param>
+        public Task HandleAsync(DataTypeSavedNotification notification, CancellationToken cancellationToken)
         {
             if (notification.SavedEntities == null || !notification.SavedEntities.Any())
-                return;
+                return Task.CompletedTask;
 
             foreach (var savedDataType in notification.SavedEntities)
             {
@@ -62,18 +50,17 @@ namespace Umbraco.Community.BlockPreview.NotificationHandlers
                 _runtimeCache.ClearByKey(string.Format(Constants.CacheKeys.DataType, savedDataType.Key));
 
                 // Cascade: Clear caches for all content types that use this data type
-                if (_contentTypeService != null)
-                {
-                    var dependentContentTypes = _contentTypeService.GetAll()
-                        .Where(ct => ct.PropertyTypes.Any(pt => pt.DataTypeKey == savedDataType.Key) ||
-                                     ct.CompositionPropertyTypes.Any(pt => pt.DataTypeKey == savedDataType.Key));
+                var dependentContentTypes = _contentTypeService.GetAll()
+                    .Where(ct => ct.PropertyTypes.Any(pt => pt.DataTypeKey == savedDataType.Key) ||
+                                 ct.CompositionPropertyTypes.Any(pt => pt.DataTypeKey == savedDataType.Key));
 
-                    foreach (var contentType in dependentContentTypes)
-                    {
-                        _runtimeCache.ClearByKey(string.Format(Constants.CacheKeys.ContentType, contentType.Key));
-                    }
+                foreach (var contentType in dependentContentTypes)
+                {
+                    _runtimeCache.ClearByKey(string.Format(Constants.CacheKeys.ContentType, contentType.Key));
                 }
             }
+
+            return Task.CompletedTask;
         }
     }
 }


### PR DESCRIPTION
## Summary

Switch notification handlers to use INotificationAsyncHandler for better async support and cleaner code.

## Based On
This PR addresses findings from [BEST-PRACTICES-REVIEW.md](https://github.com/rickbutterfield/BlockPreview/blob/v5/main/BEST-PRACTICES-REVIEW.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)