### PR TITLE
fix: Make Constants fields const instead of mutable static

### DIFF
--- a/src/Umbraco.Community.BlockPreview/Constants.cs
+++ b/src/Umbraco.Community.BlockPreview/Constants.cs
@@ -65,87 +65,87 @@
             /// <summary>
             /// Error message template for rendering errors.
             /// </summary>
-            public static string RenderError = "<strong>Something went wrong rendering a preview.</strong><br/><pre>{0}</pre>";
+            public const string RenderError = "<strong>Something went wrong rendering a preview.</strong><br/><pre>{0}</pre>";
 
             /// <summary>
             /// Error message for missing ModelsBuilder models.
             /// </summary>
-            public static string ModelsBuilderError = "Strongly typed models must be generated and exist on disk for BlockPreview to work.";
+            public const string ModelsBuilderError = "Strongly typed models must be generated and exist on disk for BlockPreview to work.";
 
             /// <summary>
             /// HTML template for error alerts.
             /// </summary>
-            public static string ErrorTemplate = "<div class=\"preview-alert preview-alert-error\">{0}</div>";
+            public const string ErrorTemplate = "<div class=\"preview-alert preview-alert-error\">{0}</div>";
 
             /// <summary>
             /// HTML template for warning alerts.
             /// </summary>
-            public static string WarningTemplate = "<div class=\"preview-alert preview-alert-warning\">{0}</div>";
+            public const string WarningTemplate = "<div class=\"preview-alert preview-alert-warning\">{0}</div>";
 
             /// <summary>
             /// Error message for missing generated models.
             /// </summary>
-            public static string NoGeneratedModels = "Generated model(s) could not be found. Please try regenerating models and restarting the application.";
+            public const string NoGeneratedModels = "Generated model(s) could not be found. Please try regenerating models and restarting the application.";
 
             /// <summary>
             /// Error message when ModelsBuilder is not configured to generate models.
             /// </summary>
-            public static string ModelsNotConfigured = "BlockPreview requires strongly-typed models. Please configure ModelsBuilder with SourceCodeAuto or SourceCodeManual mode.";
+            public const string ModelsNotConfigured = "BlockPreview requires strongly-typed models. Please configure ModelsBuilder with SourceCodeAuto or SourceCodeManual mode.";
 
             /// <summary>
             /// Error message for invalid block data.
             /// </summary>
-            public static string InvalidBlockData = "The block data is invalid.";
+            public const string InvalidBlockData = "The block data is invalid.";
 
             /// <summary>
             /// Error message for invalid content key.
             /// </summary>
-            public static string InvalidContentKey = "The content key is invalid.";
+            public const string InvalidContentKey = "The content key is invalid.";
 
             /// <summary>
             /// Error message for invalid content data.
             /// </summary>
-            public static string InvalidContentData = "The content data is invalid.";
+            public const string InvalidContentData = "The content data is invalid.";
 
             /// <summary>
             /// Error message for invalid block instance.
             /// </summary>
-            public static string InvalidBlockInstance = "The block instance is invalid.";
+            public const string InvalidBlockInstance = "The block instance is invalid.";
 
             /// <summary>
             /// Error message for invalid document type.
             /// </summary>
-            public static string InvalidDocumentType = "The document type is invalid.";
+            public const string InvalidDocumentType = "The document type is invalid.";
 
             /// <summary>
             /// Error message for invalid property type.
             /// </summary>
-            public static string InvalidPropertyType = "The property type is invalid.";
+            public const string InvalidPropertyType = "The property type is invalid.";
 
             /// <summary>
             /// Error message for invalid data type.
             /// </summary>
-            public static string InvalidDataType = "The data type is invalid.";
+            public const string InvalidDataType = "The data type is invalid.";
 
             /// <summary>
             /// Error message for invalid block grid configuration.
             /// </summary>
-            public static string InvalidBlockGridConfiguration = "The block grid configuration is invalid.";
+            public const string InvalidBlockGridConfiguration = "The block grid configuration is invalid.";
 
             /// <summary>
             /// Error message for missing matching block grid configuration.
             /// </summary>
-            public static string InvalidMatchingBlockGridConfiguration = "A matching block grid configuration could not be found";
+            public const string InvalidMatchingBlockGridConfiguration = "A matching block grid configuration could not be found";
 
             /// <summary>
             /// Error message template for view not found.
             /// </summary>
-            public static string ViewNotFound = "The view <code>{0}.cshtml</code> could not be found. Searched the following locations: <pre>{1}</pre>";
+            public const string ViewNotFound = "The view <code>{0}.cshtml</code> could not be found. Searched the following locations: <pre>{1}</pre>";
 
             /// <summary>
             /// Logger error message template.
             /// </summary>
-            public static string LoggerError = "Error rendering preview for block {0}";
+            public const string LoggerError = "Error rendering preview for block {0}";
         }
 
         /// <summary>
@@ -156,28 +156,28 @@
             /// <summary>
             /// Cache key template for content.
             /// </summary>
-            public static string Content = "BlockPreview_Content_{0}";
+            public const string Content = "BlockPreview_Content_{0}";
             
             /// <summary>
             /// Cache key for generated models.
             /// </summary>
-            public static string GeneratedModels = "BlockPreview_GeneratedModels";
+            public const string GeneratedModels = "BlockPreview_GeneratedModels";
             
             /// <summary>
             /// Cache key template for block type.
             /// </summary>
             [Obsolete("No longer used. Block types are now resolved via IPublishedModelFactory.")]
-            public static string BlockType = "BlockPreview_BlockType_{0}";
+            public const string BlockType = "BlockPreview_BlockType_{0}";
 
             /// <summary>
             /// Cache key template for content type.
             /// </summary>
-            public static string ContentType = "BlockPreview_ContentType_{0}";
+            public const string ContentType = "BlockPreview_ContentType_{0}";
             
             /// <summary>
             /// Cache key template for data type.
             /// </summary>
-            public static string DataType = "BlockPreview_DataType_{0}";
+            public const string DataType = "BlockPreview_DataType_{0}";
         }
     }
 }


### PR DESCRIPTION
## Summary

Make Constants fields const instead of mutable static to prevent runtime modifications.

## Based On
This PR addresses findings from [BEST-PRACTICES-REVIEW.md](https://github.com/rickbutterfield/BlockPreview/blob/v5/main/BEST-PRACTICES-REVIEW.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)