### PR TITLE
fix: Add null safety to HttpRequestExtensions.IsBlockPreviewRequest

### DIFF
--- a/src/Umbraco.Community.BlockPreview/Extensions/HttpRequestExtensions.cs
+++ b/src/Umbraco.Community.BlockPreview/Extensions/HttpRequestExtensions.cs
@@ -15,14 +15,20 @@ namespace Umbraco.Community.BlockPreview.Extensions
         /// <returns>True if the request is a Block Preview request; otherwise, false.</returns>
         public static bool IsBlockPreviewRequest(this HttpRequest request)
         {
-            var httpContext = request.HttpContext;
+            var routeValues = request.HttpContext.Request.RouteValues;
 
-            string requestControllerName = (string)httpContext.Request.RouteValues["controller"]! + "Controller";
+            if (!routeValues.TryGetValue("controller", out var controllerValue) ||
+                !routeValues.TryGetValue("action", out var actionValue))
+            {
+                return false;
+            }
+
+            string requestControllerName = (string)controllerValue! + "Controller";
 
             bool requestControllerMatches = requestControllerName.Equals(nameof(BlockPreviewApiController));
-            bool isBlockGridPreview = httpContext.Request.RouteValues["action"]!.Equals(nameof(BlockPreviewApiController.PreviewGridBlock));
-            bool isBlockListPreview = httpContext.Request.RouteValues["action"]!.Equals(nameof(BlockPreviewApiController.PreviewListBlock));
-            bool isRichTextPreview = httpContext.Request.RouteValues["action"]!.Equals(nameof(BlockPreviewApiController.PreviewRichTextMarkup));
+            bool isBlockGridPreview = actionValue!.Equals(nameof(BlockPreviewApiController.PreviewGridBlock));
+            bool isBlockListPreview = actionValue.Equals(nameof(BlockPreviewApiController.PreviewListBlock));
+            bool isRichTextPreview = actionValue.Equals(nameof(BlockPreviewApiController.PreviewRichTextMarkup));
 
             return requestControllerMatches && (isBlockGridPreview || isBlockListPreview || isRichTextPreview);
         }

--- a/src/Umbraco.Community.BlockPreview/Extensions/HttpRequestExtensions.cs
+++ b/src/Umbraco.Community.BlockPreview/Extensions/HttpRequestExtensions.cs
@@ -15,20 +15,22 @@ namespace Umbraco.Community.BlockPreview.Extensions
         /// <returns>True if the request is a Block Preview request; otherwise, false.</returns>
         public static bool IsBlockPreviewRequest(this HttpRequest request)
         {
-            var routeValues = request.HttpContext.Request.RouteValues;
+            var routeValues = request.RouteValues;
 
             if (!routeValues.TryGetValue("controller", out var controllerValue) ||
-                !routeValues.TryGetValue("action", out var actionValue))
+                !routeValues.TryGetValue("action", out var actionValue) ||
+                controllerValue is not string controller ||
+                actionValue is not string action)
             {
                 return false;
             }
 
-            string requestControllerName = (string)controllerValue! + "Controller";
+            string requestControllerName = controller + "Controller";
 
             bool requestControllerMatches = requestControllerName.Equals(nameof(BlockPreviewApiController));
-            bool isBlockGridPreview = actionValue!.Equals(nameof(BlockPreviewApiController.PreviewGridBlock));
-            bool isBlockListPreview = actionValue.Equals(nameof(BlockPreviewApiController.PreviewListBlock));
-            bool isRichTextPreview = actionValue.Equals(nameof(BlockPreviewApiController.PreviewRichTextMarkup));
+            bool isBlockGridPreview = action.Equals(nameof(BlockPreviewApiController.PreviewGridBlock));
+            bool isBlockListPreview = action.Equals(nameof(BlockPreviewApiController.PreviewListBlock));
+            bool isRichTextPreview = action.Equals(nameof(BlockPreviewApiController.PreviewRichTextMarkup));
 
             return requestControllerMatches && (isBlockGridPreview || isBlockListPreview || isRichTextPreview);
         }

--- a/tests/Umbraco.Community.BlockPreview.Tests/Extensions/HttpRequestExtensionsTests.cs
+++ b/tests/Umbraco.Community.BlockPreview.Tests/Extensions/HttpRequestExtensionsTests.cs
@@ -1,0 +1,139 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using NUnit.Framework;
+using Umbraco.Community.BlockPreview.Extensions;
+
+namespace Umbraco.Community.BlockPreview.Tests.Extensions;
+
+[TestFixture]
+public class HttpRequestExtensionsTests
+{
+    private static HttpRequest CreateRequest(RouteValueDictionary? routeValues = null)
+    {
+        var context = new DefaultHttpContext();
+
+        if (routeValues != null)
+        {
+            foreach (var kvp in routeValues)
+            {
+                context.Request.RouteValues[kvp.Key] = kvp.Value;
+            }
+        }
+
+        return context.Request;
+    }
+
+    [Test]
+    public void IsBlockPreviewRequest_WithPreviewGridBlock_ReturnsTrue()
+    {
+        var request = CreateRequest(new RouteValueDictionary
+        {
+            { "controller", "BlockPreviewApi" },
+            { "action", "PreviewGridBlock" }
+        });
+
+        Assert.That(request.IsBlockPreviewRequest(), Is.True);
+    }
+
+    [Test]
+    public void IsBlockPreviewRequest_WithPreviewListBlock_ReturnsTrue()
+    {
+        var request = CreateRequest(new RouteValueDictionary
+        {
+            { "controller", "BlockPreviewApi" },
+            { "action", "PreviewListBlock" }
+        });
+
+        Assert.That(request.IsBlockPreviewRequest(), Is.True);
+    }
+
+    [Test]
+    public void IsBlockPreviewRequest_WithPreviewRichTextMarkup_ReturnsTrue()
+    {
+        var request = CreateRequest(new RouteValueDictionary
+        {
+            { "controller", "BlockPreviewApi" },
+            { "action", "PreviewRichTextMarkup" }
+        });
+
+        Assert.That(request.IsBlockPreviewRequest(), Is.True);
+    }
+
+    [Test]
+    public void IsBlockPreviewRequest_WithMissingRouteValues_ReturnsFalse()
+    {
+        var request = CreateRequest();
+
+        Assert.That(request.IsBlockPreviewRequest(), Is.False);
+    }
+
+    [Test]
+    public void IsBlockPreviewRequest_WithMissingController_ReturnsFalse()
+    {
+        var request = CreateRequest(new RouteValueDictionary
+        {
+            { "action", "PreviewGridBlock" }
+        });
+
+        Assert.That(request.IsBlockPreviewRequest(), Is.False);
+    }
+
+    [Test]
+    public void IsBlockPreviewRequest_WithMissingAction_ReturnsFalse()
+    {
+        var request = CreateRequest(new RouteValueDictionary
+        {
+            { "controller", "BlockPreviewApi" }
+        });
+
+        Assert.That(request.IsBlockPreviewRequest(), Is.False);
+    }
+
+    [Test]
+    public void IsBlockPreviewRequest_WithNullRouteValues_ReturnsFalse()
+    {
+        var request = CreateRequest(new RouteValueDictionary
+        {
+            { "controller", null },
+            { "action", null }
+        });
+
+        Assert.That(request.IsBlockPreviewRequest(), Is.False);
+    }
+
+    [Test]
+    public void IsBlockPreviewRequest_WithWrongController_ReturnsFalse()
+    {
+        var request = CreateRequest(new RouteValueDictionary
+        {
+            { "controller", "SomeOther" },
+            { "action", "PreviewGridBlock" }
+        });
+
+        Assert.That(request.IsBlockPreviewRequest(), Is.False);
+    }
+
+    [Test]
+    public void IsBlockPreviewRequest_WithWrongAction_ReturnsFalse()
+    {
+        var request = CreateRequest(new RouteValueDictionary
+        {
+            { "controller", "BlockPreviewApi" },
+            { "action", "SomeOtherAction" }
+        });
+
+        Assert.That(request.IsBlockPreviewRequest(), Is.False);
+    }
+
+    [Test]
+    public void IsBlockPreviewRequest_WithNonStringRouteValues_ReturnsFalse()
+    {
+        var request = CreateRequest(new RouteValueDictionary
+        {
+            { "controller", 123 },
+            { "action", 456 }
+        });
+
+        Assert.That(request.IsBlockPreviewRequest(), Is.False);
+    }
+}


### PR DESCRIPTION
## Summary

Add null safety checks to HttpRequestExtensions.IsBlockPreviewRequest to prevent NullReferenceException.

## Based On
This PR addresses findings from [BEST-PRACTICES-REVIEW.md](https://github.com/rickbutterfield/BlockPreview/blob/v5/main/BEST-PRACTICES-REVIEW.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)