### PR TITLE
fix: Use IOptionsMonitor in singleton BlockPreviewViewResolver

### DIFF
--- a/src/Umbraco.Community.BlockPreview/Services/BlockPreviewViewResolver.cs
+++ b/src/Umbraco.Community.BlockPreview/Services/BlockPreviewViewResolver.cs
@@ -23,22 +23,22 @@ namespace Umbraco.Community.BlockPreview.Services
 
         private readonly IRazorViewEngine _razorViewEngine;
         private readonly IWebHostEnvironment _webHostEnvironment;
-        private readonly BlockPreviewOptions _options;
+        private readonly IOptionsMonitor<BlockPreviewOptions> _optionsMonitor;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BlockPreviewViewResolver"/> class.
         /// </summary>
         /// <param name="razorViewEngine">The Razor view engine.</param>
         /// <param name="webHostEnvironment">The web host environment.</param>
-        /// <param name="options">The block preview options.</param>
+        /// <param name="optionsMonitor">The block preview options monitor.</param>
         public BlockPreviewViewResolver(
             IRazorViewEngine razorViewEngine,
             IWebHostEnvironment webHostEnvironment,
-            IOptions<BlockPreviewOptions> options)
+            IOptionsMonitor<BlockPreviewOptions> optionsMonitor)
         {
             _razorViewEngine = razorViewEngine;
             _webHostEnvironment = webHostEnvironment;
-            _options = options.Value;
+            _optionsMonitor = optionsMonitor;
         }
 
         /// <inheritdoc/>
@@ -93,7 +93,7 @@ namespace Umbraco.Community.BlockPreview.Services
         /// </summary>
         private string FindViewPath(string contentAlias, BlockType blockType)
         {
-            var viewPaths = _options.GetViewLocations(blockType);
+            var viewPaths = _optionsMonitor.CurrentValue.GetViewLocations(blockType);
 
             if (viewPaths == null || viewPaths.Count == 0)
                 return NotFoundSentinel;

--- a/src/Umbraco.Community.BlockPreview/Services/BlockPreviewViewResolver.cs
+++ b/src/Umbraco.Community.BlockPreview/Services/BlockPreviewViewResolver.cs
@@ -39,6 +39,7 @@ namespace Umbraco.Community.BlockPreview.Services
             _razorViewEngine = razorViewEngine;
             _webHostEnvironment = webHostEnvironment;
             _optionsMonitor = optionsMonitor;
+            _optionsMonitor.OnChange(_ => ClearCache());
         }
 
         /// <inheritdoc/>

--- a/tests/Umbraco.Community.BlockPreview.Tests/Services/BlockPreviewViewResolverTests.cs
+++ b/tests/Umbraco.Community.BlockPreview.Tests/Services/BlockPreviewViewResolverTests.cs
@@ -41,13 +41,15 @@ public class BlockPreviewViewResolverTests
             }
         };
 
-        var optionsMock = new Mock<IOptions<BlockPreviewOptions>>();
-        optionsMock.Setup(o => o.Value).Returns(_options);
+        var optionsMonitorMock = new Mock<IOptionsMonitor<BlockPreviewOptions>>();
+        optionsMonitorMock.Setup(o => o.CurrentValue).Returns(_options);
+        optionsMonitorMock.Setup(o => o.OnChange(It.IsAny<Action<BlockPreviewOptions, string?>>()))
+            .Returns(Mock.Of<IDisposable>());
 
         _resolver = new BlockPreviewViewResolver(
             _razorViewEngineMock.Object,
             _webHostEnvironmentMock.Object,
-            optionsMock.Object);
+            optionsMonitorMock.Object);
 
         // Clear cache before each test
         _resolver.ClearCache();


### PR DESCRIPTION
## Summary

Use IOptionsMonitor in singleton BlockPreviewViewResolver to properly handle option changes.

## Based On
This PR addresses findings from [BEST-PRACTICES-REVIEW.md](https://github.com/rickbutterfield/BlockPreview/blob/v5/main/BEST-PRACTICES-REVIEW.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)