### PR TITLE
fix: Remove [AllowAnonymous] from settings endpoint

### DIFF
--- a/src/Umbraco.Community.BlockPreview/Controllers/BlockPreviewApiController.cs
+++ b/src/Umbraco.Community.BlockPreview/Controllers/BlockPreviewApiController.cs
@@ -1,6 +1,5 @@
 ﻿using Asp.Versioning;
 using HtmlAgilityPack;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
@@ -306,7 +305,6 @@ namespace Umbraco.Community.BlockPreview.Controllers
         /// Loads the in-memory settings from appsettings.json
         /// </summary>
         /// <returns><see cref="BlockPreviewOptions">Block Preview settings</see></returns>
-        [AllowAnonymous]
         [HttpGet("settings")]
         [ProducesResponseType(typeof(BlockPreviewOptions), 200)]
         public BlockPreviewOptions GetSettings()


### PR DESCRIPTION
## Summary

Remove [AllowAnonymous] attribute from settings endpoint for security.

## Based On
This PR addresses findings from [BEST-PRACTICES-REVIEW.md](https://github.com/rickbutterfield/BlockPreview/blob/v5/main/BEST-PRACTICES-REVIEW.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)