### PR TITLE
refactor: Remove obsolete constructors using StaticServiceProvider

### DIFF
--- a/src/Umbraco.Community.BlockPreview/Controllers/BlockPreviewApiController.cs
+++ b/src/Umbraco.Community.BlockPreview/Controllers/BlockPreviewApiController.cs
@@ -10,7 +10,6 @@ using Microsoft.Extensions.Options;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Composing;
-using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PublishedCache;
 using Umbraco.Cms.Core.Routing;
@@ -52,7 +51,6 @@ namespace Umbraco.Community.BlockPreview.Controllers
         /// <summary>
         /// Initializes a new instance of the <see cref="BlockPreviewApiController"/> class.
         /// </summary>
-        [ActivatorUtilitiesConstructor]
         public BlockPreviewApiController(
             IPublishedRouter publishedRouter,
             ILogger<BlockPreviewApiController> logger,
@@ -84,44 +82,6 @@ namespace Umbraco.Community.BlockPreview.Controllers
             _scopeProvider = scopeProvider;
             _requestEnricher = requestEnricher;
             _responseEnricher = responseEnricher;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="BlockPreviewApiController"/> class.
-        /// </summary>
-        [Obsolete("Use the constructor with IBlockPreviewResponseEnricher parameter instead.")]
-        public BlockPreviewApiController(
-            IPublishedRouter publishedRouter,
-            ILogger<BlockPreviewApiController> logger,
-            IUmbracoContextAccessor umbracoContextAccessor,
-            ContextCultureService contextCultureSwitcher,
-            IBlockPreviewService blockPreviewService,
-            ILanguageService languageService,
-            IOptions<BlockPreviewOptions> blockPreviewSettings,
-            ITypeFinder typeFinder,
-            AppCaches appCaches,
-            IElementsCache elementsCache,
-            IDocumentCacheService documentCacheService,
-            IPublishedContentTypeCache contentTypeCache,
-            IScopeProvider scopeProvider,
-            IBlockPreviewRequestEnricher requestEnricher)
-            : this(
-                publishedRouter,
-                logger,
-                umbracoContextAccessor,
-                contextCultureSwitcher,
-                blockPreviewService,
-                languageService,
-                blockPreviewSettings,
-                typeFinder,
-                appCaches,
-                elementsCache,
-                documentCacheService,
-                contentTypeCache,
-                scopeProvider,
-                requestEnricher,
-                StaticServiceProvider.Instance.GetRequiredService<IBlockPreviewResponseEnricher>())
-        {
         }
 
         #region Public

--- a/src/Umbraco.Community.BlockPreview/NotificationHandlers/ContentTypeSavedNotificationHandler.cs
+++ b/src/Umbraco.Community.BlockPreview/NotificationHandlers/ContentTypeSavedNotificationHandler.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.Extensions.DependencyInjection;
-using Umbraco.Cms.Core.Cache;
-using Umbraco.Cms.Core.DependencyInjection;
+﻿using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Notifications;
@@ -26,16 +24,6 @@ namespace Umbraco.Community.BlockPreview.NotificationHandlers
         {
             _runtimeCache = appCaches.RuntimeCache;
             _viewResolver = viewResolver;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ContentTypeSavedNotificationHandler"/> class.
-        /// </summary>
-        /// <param name="appCaches">The application caches.</param>
-        [Obsolete("Use the constructor that accepts IBlockPreviewViewResolver.")]
-        public ContentTypeSavedNotificationHandler(AppCaches appCaches)
-            : this(appCaches, StaticServiceProvider.Instance.GetRequiredService<IBlockPreviewViewResolver>())
-        {
         }
 
         /// <summary>

--- a/src/Umbraco.Community.BlockPreview/NotificationHandlers/DataTypeSavedNotificationHandler.cs
+++ b/src/Umbraco.Community.BlockPreview/NotificationHandlers/DataTypeSavedNotificationHandler.cs
@@ -1,11 +1,9 @@
 ﻿using Umbraco.Cms.Core.Cache;
-using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Extensions;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Umbraco.Community.BlockPreview.NotificationHandlers
 {
@@ -15,7 +13,7 @@ namespace Umbraco.Community.BlockPreview.NotificationHandlers
     public class DataTypeSavedNotificationHandler : INotificationHandler<DataTypeSavedNotification>
     {
         private readonly IAppPolicyCache _runtimeCache;
-        private readonly IContentTypeService? _contentTypeService;
+        private readonly IContentTypeService _contentTypeService;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DataTypeSavedNotificationHandler"/> class.
@@ -26,16 +24,6 @@ namespace Umbraco.Community.BlockPreview.NotificationHandlers
         {
             _runtimeCache = appCaches.RuntimeCache;
             _contentTypeService = contentTypeService;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DataTypeSavedNotificationHandler"/> class.
-        /// </summary>
-        /// <param name="appCaches">The application caches.</param>
-        [Obsolete("Use the constructor that accepts IContentTypeService for cascading cache invalidation.")]
-        public DataTypeSavedNotificationHandler(AppCaches appCaches)
-            : this(appCaches, StaticServiceProvider.Instance.GetRequiredService<IContentTypeService>())
-        {
         }
 
         /// <summary>
@@ -62,16 +50,13 @@ namespace Umbraco.Community.BlockPreview.NotificationHandlers
                 _runtimeCache.ClearByKey(string.Format(Constants.CacheKeys.DataType, savedDataType.Key));
 
                 // Cascade: Clear caches for all content types that use this data type
-                if (_contentTypeService != null)
-                {
-                    var dependentContentTypes = _contentTypeService.GetAll()
-                        .Where(ct => ct.PropertyTypes.Any(pt => pt.DataTypeKey == savedDataType.Key) ||
-                                     ct.CompositionPropertyTypes.Any(pt => pt.DataTypeKey == savedDataType.Key));
+                var dependentContentTypes = _contentTypeService.GetAll()
+                    .Where(ct => ct.PropertyTypes.Any(pt => pt.DataTypeKey == savedDataType.Key) ||
+                                 ct.CompositionPropertyTypes.Any(pt => pt.DataTypeKey == savedDataType.Key));
 
-                    foreach (var contentType in dependentContentTypes)
-                    {
-                        _runtimeCache.ClearByKey(string.Format(Constants.CacheKeys.ContentType, contentType.Key));
-                    }
+                foreach (var contentType in dependentContentTypes)
+                {
+                    _runtimeCache.ClearByKey(string.Format(Constants.CacheKeys.ContentType, contentType.Key));
                 }
             }
         }

--- a/src/Umbraco.Community.BlockPreview/Services/BlockPreviewService.cs
+++ b/src/Umbraco.Community.BlockPreview/Services/BlockPreviewService.cs
@@ -1,24 +1,14 @@
-﻿using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
-using Microsoft.AspNetCore.Mvc.Razor;
-using Microsoft.AspNetCore.Mvc.ViewComponents;
 using Microsoft.AspNetCore.Mvc.ViewEngines;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Umbraco.Cms.Core.Cache;
-using Umbraco.Cms.Core.Cache.PropertyEditors;
-using Umbraco.Cms.Core.Composing;
-using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Blocks;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.PropertyEditors.ValueConverters;
 using Umbraco.Cms.Core.Serialization;
-using Umbraco.Cms.Core.Services;
 using Umbraco.Community.BlockPreview.Enums;
 using Umbraco.Community.BlockPreview.Interfaces;
 using Umbraco.Extensions;
@@ -53,7 +43,6 @@ namespace Umbraco.Community.BlockPreview.Services
         /// <param name="blockDataConverter">The block data converter.</param>
         /// <param name="blockTypeCacheService">The block type cache service.</param>
         /// <param name="viewResolver">The view resolver.</param>
-        [ActivatorUtilitiesConstructor]
         public BlockPreviewService(
             IPublishedModelFactory publishedModelFactory,
             BlockEditorConverter blockEditorConverter,
@@ -74,95 +63,6 @@ namespace Umbraco.Community.BlockPreview.Services
             _blockTypeCacheService = blockTypeCacheService;
             _viewResolver = viewResolver;
             _hasModelFactory = publishedModelFactory is not NoopPublishedModelFactory;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="BlockPreviewService"/> class.
-        /// </summary>
-        /// <param name="tempDataProvider">No longer used.</param>
-        /// <param name="viewComponentHelperWrapper">No longer used.</param>
-        /// <param name="razorViewEngine">The Razor view engine.</param>
-        /// <param name="publishedModelFactory">The published model factory.</param>
-        /// <param name="blockEditorConverter">The block editor converter.</param>
-        /// <param name="viewComponentSelector">No longer used.</param>
-        /// <param name="publishedValueFallback">No longer used.</param>
-        /// <param name="options">The block preview options.</param>
-        /// <param name="jsonSerializer">The JSON serializer.</param>
-        /// <param name="contentTypeService">No longer used.</param>
-        /// <param name="dataTypeService">No longer used.</param>
-        /// <param name="appCaches">No longer used.</param>
-        /// <param name="webHostEnvironment">The web host environment.</param>
-        /// <param name="elementTypeCache">No longer used.</param>
-        /// <param name="logger">No longer used.</param>
-        /// <param name="blockModelFactory">The block model factory.</param>
-        /// <param name="blockViewRenderer">The block view renderer.</param>
-        /// <param name="blockDataConverter">The block data converter.</param>
-        /// <param name="blockTypeCacheService">The block type cache service.</param>
-        [Obsolete("Use the constructor with fewer parameters. Several dependencies are no longer used.")]
-        public BlockPreviewService(
-            ITempDataProvider tempDataProvider,
-            IViewComponentHelperWrapper viewComponentHelperWrapper,
-            IRazorViewEngine razorViewEngine,
-            IPublishedModelFactory publishedModelFactory,
-            BlockEditorConverter blockEditorConverter,
-            IViewComponentSelector viewComponentSelector,
-            IPublishedValueFallback publishedValueFallback,
-            IOptions<BlockPreviewOptions> options,
-            IJsonSerializer jsonSerializer,
-            IContentTypeService contentTypeService,
-            IDataTypeService dataTypeService,
-            AppCaches appCaches,
-            IWebHostEnvironment webHostEnvironment,
-            IBlockEditorElementTypeCache elementTypeCache,
-            ILogger<BlockPreviewService> logger,
-            IBlockModelFactory blockModelFactory,
-            IBlockViewRenderer blockViewRenderer,
-            IBlockDataConverter blockDataConverter,
-            IBlockTypeCacheService blockTypeCacheService)
-            : this(
-                publishedModelFactory,
-                blockEditorConverter,
-                options,
-                jsonSerializer,
-                blockModelFactory,
-                blockViewRenderer,
-                blockDataConverter,
-                blockTypeCacheService,
-                StaticServiceProvider.Instance.GetRequiredService<IBlockPreviewViewResolver>())
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="BlockPreviewService"/> class.
-        /// </summary>
-        [Obsolete("Use the constructor that accepts IPublishedModelFactory and IBlockModelFactory instead. This constructor will be removed in a future version.")]
-        public BlockPreviewService(
-            ITempDataProvider tempDataProvider,
-            IViewComponentHelperWrapper viewComponentHelperWrapper,
-            IRazorViewEngine razorViewEngine,
-            ITypeFinder typeFinder,
-            BlockEditorConverter blockEditorConverter,
-            IViewComponentSelector viewComponentSelector,
-            IPublishedValueFallback publishedValueFallback,
-            IOptions<BlockPreviewOptions> options,
-            IJsonSerializer jsonSerializer,
-            IContentTypeService contentTypeService,
-            IDataTypeService dataTypeService,
-            AppCaches appCaches,
-            IWebHostEnvironment webHostEnvironment,
-            IBlockEditorElementTypeCache elementTypeCache,
-            ILogger<BlockPreviewService> logger)
-            : this(
-                StaticServiceProvider.Instance.GetRequiredService<IPublishedModelFactory>(),
-                blockEditorConverter,
-                options,
-                jsonSerializer,
-                StaticServiceProvider.Instance.GetRequiredService<IBlockModelFactory>(),
-                StaticServiceProvider.Instance.GetRequiredService<IBlockViewRenderer>(),
-                StaticServiceProvider.Instance.GetRequiredService<IBlockDataConverter>(),
-                StaticServiceProvider.Instance.GetRequiredService<IBlockTypeCacheService>(),
-                StaticServiceProvider.Instance.GetRequiredService<IBlockPreviewViewResolver>())
-        {
         }
 
         #region Public

--- a/src/Umbraco.Community.BlockPreview/Services/BlockViewRenderer.cs
+++ b/src/Umbraco.Community.BlockPreview/Services/BlockViewRenderer.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System.Text.Encodings.Web;
-using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Community.BlockPreview.Extensions;
 using Umbraco.Community.BlockPreview.Helpers;
 using Umbraco.Community.BlockPreview.Interfaces;
@@ -37,7 +36,6 @@ namespace Umbraco.Community.BlockPreview.Services
         /// <param name="viewComponentSelector">The view component selector.</param>
         /// <param name="serviceScopeFactory">The service scope factory.</param>
         /// <param name="logger">The logger.</param>
-        [ActivatorUtilitiesConstructor]
         public BlockViewRenderer(
             ITempDataProvider tempDataProvider,
             IViewComponentHelperWrapper viewComponentHelperWrapper,
@@ -52,29 +50,6 @@ namespace Umbraco.Community.BlockPreview.Services
             _viewComponentSelector = viewComponentSelector;
             _serviceScopeFactory = serviceScopeFactory;
             _logger = logger;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="BlockViewRenderer"/> class.
-        /// </summary>
-        /// <param name="tempDataProvider">The temp data provider.</param>
-        /// <param name="viewComponentHelperWrapper">The view component helper wrapper.</param>
-        /// <param name="razorViewEngine">The Razor view engine.</param>
-        /// <param name="viewComponentSelector">The view component selector.</param>
-        [Obsolete("Use the constructor that accepts IServiceScopeFactory. Scheduled for removal in v6.")]
-        public BlockViewRenderer(
-            ITempDataProvider tempDataProvider,
-            IViewComponentHelperWrapper viewComponentHelperWrapper,
-            IRazorViewEngine razorViewEngine,
-            IViewComponentSelector viewComponentSelector)
-            : this(
-                tempDataProvider,
-                viewComponentHelperWrapper,
-                razorViewEngine,
-                viewComponentSelector,
-                StaticServiceProvider.Instance.GetRequiredService<IServiceScopeFactory>(),
-                StaticServiceProvider.Instance.GetRequiredService<ILogger<BlockViewRenderer>>())
-        {
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
## Summary

Remove obsolete constructors using StaticServiceProvider and rely on dependency injection.

## Based On
This PR addresses findings from [BEST-PRACTICES-REVIEW.md](https://github.com/rickbutterfield/BlockPreview/blob/v5/main/BEST-PRACTICES-REVIEW.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)