### PR TITLE
fix: Don't set fallback content as AssignedContentItem

### DIFF
--- a/src/Umbraco.Community.BlockPreview/Controllers/BlockPreviewApiController.cs
+++ b/src/Umbraco.Community.BlockPreview/Controllers/BlockPreviewApiController.cs
@@ -157,11 +157,11 @@ namespace Umbraco.Community.BlockPreview.Controllers
             {
                 try
                 {
-                    IPublishedContent? content = GetPublishedContent(nodeKey, documentTypeUnique);
+                    IPublishedContent? content = GetPublishedContent(nodeKey, documentTypeUnique, out bool isActualContent);
 
                     string? currentCulture = await GetCurrentCulture(culture, content);
 
-                    await SetupPublishedRequest(currentCulture, content);
+                    await SetupPublishedRequest(currentCulture, isActualContent ? content : null);
 
                     await _requestEnricher.EnrichAsync(HttpContext, content, blockEditorAlias, contentElementAlias, contentUdi, settingsUdi, blockIndex);
 
@@ -218,11 +218,11 @@ namespace Umbraco.Community.BlockPreview.Controllers
             {
                 try
                 {
-                    IPublishedContent? content = GetPublishedContent(nodeKey, documentTypeUnique);
+                    IPublishedContent? content = GetPublishedContent(nodeKey, documentTypeUnique, out bool isActualContent);
 
                     string? currentCulture = await GetCurrentCulture(culture, content);
 
-                    await SetupPublishedRequest(currentCulture, content);
+                    await SetupPublishedRequest(currentCulture, isActualContent ? content : null);
 
                     await _requestEnricher.EnrichAsync(HttpContext, content, blockEditorAlias, contentElementAlias, contentUdi, settingsUdi, blockIndex);
 
@@ -273,11 +273,11 @@ namespace Umbraco.Community.BlockPreview.Controllers
             {
                 try
                 {
-                    IPublishedContent? content = GetPublishedContent(nodeKey, documentTypeUnique);
+                    IPublishedContent? content = GetPublishedContent(nodeKey, documentTypeUnique, out bool isActualContent);
 
                     string? currentCulture = await GetCurrentCulture(culture, content);
 
-                    await SetupPublishedRequest(currentCulture, content);
+                    await SetupPublishedRequest(currentCulture, isActualContent ? content : null);
 
                     await _requestEnricher.EnrichAsync(HttpContext, content, blockEditorAlias, contentElementAlias);
 
@@ -561,6 +561,13 @@ namespace Umbraco.Community.BlockPreview.Controllers
 
         private IPublishedContent? GetPublishedContent(Guid? nodeKey = default, Guid? documentTypeUnique = default)
         {
+            return GetPublishedContent(nodeKey, documentTypeUnique, out _);
+        }
+
+        private IPublishedContent? GetPublishedContent(Guid? nodeKey, Guid? documentTypeUnique, out bool isActualContent)
+        {
+            isActualContent = false;
+
             if (!_umbracoContextAccessor.TryGetUmbracoContext(out IUmbracoContext? context))
                 return null;
 
@@ -568,18 +575,21 @@ namespace Umbraco.Community.BlockPreview.Controllers
 
             if (nodeKey.HasValue)
             {
-                content = context.Content?.GetById(preview: true, nodeKey.GetValueOrDefault());                
+                content = context.Content?.GetById(preview: true, nodeKey.GetValueOrDefault());
             }
 
-            var contentCacheKey = string.Format(Constants.CacheKeys.Content, nodeKey);
             if (content != null)
+            {
+                isActualContent = true;
                 return content;
+            }
 
             var publishedContentType = _contentTypeCache.Get(PublishedItemType.Content, documentTypeUnique.GetValueOrDefault());
 
             if (publishedContentType == null)
                 return null;
 
+            var contentCacheKey = string.Format(Constants.CacheKeys.Content, nodeKey);
             using var scope = _scopeProvider.CreateScope();
             var cacheItem = _runtimeCache.GetCacheItem(contentCacheKey, () =>
             {


### PR DESCRIPTION
## Summary
- Fixes block previews showing content from the wrong page when using `Umbraco.AssignedContentItem` in blueprints, unsaved pages, and new pages
- When the actual content can't be found by `nodeKey`, `GetPublishedContent` falls back to an arbitrary published page of the same document type. This fallback was being set as `PublishedRequest.PublishedContent`, causing `AssignedContentItem` to resolve to the wrong page
- Now tracks whether content was found by its real key or via the document-type fallback, and only sets `PublishedRequest.PublishedContent` for actual content

Fixes #271

## Test plan
- [ ] Create a document type with a block grid property and page-level properties (e.g. `pageTitle`)
- [ ] Create a block element type that reads from `Umbraco.AssignedContentItem` (no stored properties of its own)
- [ ] Create a published content page with real values
- [ ] Create a Document Blueprint of the same type with placeholder values
- [ ] Verify the blueprint's block preview shows the blueprint's placeholder values, not the published page's values
- [ ] Verify blocks on new unsaved pages don't show content from other pages
- [ ] Verify blocks with their own stored content (e.g. RTE blocks) still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)