### PR TITLE
Support setting correct values for nested blocklists

### DIFF
--- a/src/Umbraco.Community.BlockPreview/Services/BlockDataConverter.cs
+++ b/src/Umbraco.Community.BlockPreview/Services/BlockDataConverter.cs
@@ -96,7 +96,6 @@ namespace Umbraco.Community.BlockPreview.Services
                 {
                     var property = data.Values.ElementAt(i);
                     var value = property.Value;
-                    string? propertyAsString = value?.ToString();
 
                     if (property.EditorAlias == PropertyEditors.Aliases.RichText)
                     {
@@ -116,7 +115,7 @@ namespace Umbraco.Community.BlockPreview.Services
                     }
                     if (property.EditorAlias == PropertyEditors.Aliases.BlockGrid)
                     {
-                        var blockValue = _blockGridEditorValues.DeserializeAndClean(propertyAsString);
+                        var blockValue = _blockGridEditorValues.DeserializeAndClean(value);
                         if (blockValue != null)
                         {
                             FormatBlockData(blockValue.BlockValue.ContentData);
@@ -126,7 +125,7 @@ namespace Umbraco.Community.BlockPreview.Services
                     }
                     if (property.EditorAlias == PropertyEditors.Aliases.BlockList)
                     {
-                        var blockValue = _blockListEditorValues.DeserializeAndClean(propertyAsString);
+                        var blockValue = _blockListEditorValues.DeserializeAndClean(value);
                         if (blockValue != null)
                         {
                             FormatBlockData(blockValue.BlockValue.ContentData);
@@ -172,11 +171,9 @@ namespace Umbraco.Community.BlockPreview.Services
                             }
                         }
                     }
-
                     else if (propertyData.EditorAlias == PropertyEditors.Aliases.BlockGrid)
                     {
-                        string? propertyAsString = propertyData.Value?.ToString();
-                        var blockValue = _blockGridEditorValues.DeserializeAndClean(propertyAsString);
+                        var blockValue = _blockGridEditorValues.DeserializeAndClean(propertyData.Value);
                         if (blockValue != null)
                         {
                             FormatBlockData(blockValue.BlockValue.ContentData);
@@ -184,11 +181,9 @@ namespace Umbraco.Community.BlockPreview.Services
                             propertyData.Value = JsonSerializer.Serialize(blockValue.BlockValue, _jsonSerializerOptions);
                         }
                     }
-
                     else if (propertyData.EditorAlias == PropertyEditors.Aliases.BlockList)
                     {
-                        string? propertyAsString = propertyData.Value?.ToString();
-                        var blockValue = _blockListEditorValues.DeserializeAndClean(propertyAsString);
+                        var blockValue = _blockListEditorValues.DeserializeAndClean(propertyData.Value);
                         if (blockValue != null)
                         {
                             FormatBlockData(blockValue.BlockValue.ContentData);
@@ -196,7 +191,6 @@ namespace Umbraco.Community.BlockPreview.Services
                             propertyData.Value = JsonSerializer.Serialize(blockValue.BlockValue, _jsonSerializerOptions);
                         }
                     }
-
                     else ConvertPropertyValue(propertyData);
                 }
             }

--- a/src/Umbraco.Community.BlockPreview/Services/BlockDataConverter.cs
+++ b/src/Umbraco.Community.BlockPreview/Services/BlockDataConverter.cs
@@ -176,8 +176,6 @@ namespace Umbraco.Community.BlockPreview.Services
                         var blockValue = _blockGridEditorValues.DeserializeAndClean(propertyData.Value);
                         if (blockValue != null)
                         {
-                            FormatBlockData(blockValue.BlockValue.ContentData);
-                            FormatBlockData(blockValue.BlockValue.SettingsData);
                             propertyData.Value = JsonSerializer.Serialize(blockValue.BlockValue, _jsonSerializerOptions);
                         }
                     }

--- a/src/Umbraco.Community.BlockPreview/Services/BlockDataConverter.cs
+++ b/src/Umbraco.Community.BlockPreview/Services/BlockDataConverter.cs
@@ -186,8 +186,6 @@ namespace Umbraco.Community.BlockPreview.Services
                         var blockValue = _blockListEditorValues.DeserializeAndClean(propertyData.Value);
                         if (blockValue != null)
                         {
-                            FormatBlockData(blockValue.BlockValue.ContentData);
-                            FormatBlockData(blockValue.BlockValue.SettingsData);
                             propertyData.Value = JsonSerializer.Serialize(blockValue.BlockValue, _jsonSerializerOptions);
                         }
                     }


### PR DESCRIPTION
By removing the FormatBlockData when editorAlias = BlockList/BlockGrid it looks like the preview is working for nested blocklists. Also did some refactoring because _blockGridEditorValues.DeserializeAndClean already does a `.ToString()`.

I couldn't test the BlockGrid because we don't use it in our solutions.

Fix for https://github.com/rickbutterfield/BlockPreview/issues/284.