### PR TITLE
fix: Prevent Block Grid area previews rendering before layoutAreas are available

### DIFF
--- a/src/Umbraco.Community.BlockPreview.UI/src/blockEditor/block-grid-preview.custom-view.element.ts
+++ b/src/Umbraco.Community.BlockPreview.UI/src/blockEditor/block-grid-preview.custom-view.element.ts
@@ -119,8 +119,15 @@ export class BlockGridPreviewCustomView extends BlockPreviewBaseElement<BlockGri
                             await this.#observeBlockPropertyValue();
                         }
 
-                        // Re-render when layoutAreas first arrive for a block with areas
-                        if (this._htmlMarkup && !this._isLoading && !prevLayoutAreas && layoutAreas && (areas?.length ?? 0) > 0) {
+                        // Re-render when layoutAreas first arrive for a block with areas.
+                        // Covers both the deferred case (_htmlMarkup empty) and the early-render
+                        // case (_htmlMarkup set from an incomplete render). blockGridValue.layout
+                        // must be rebuilt here so callPreviewApi() sends the updated area data.
+                        if (!prevLayoutAreas && layoutAreas && (areas?.length ?? 0) > 0 && this.#managerObserved && !this._isLoading) {
+                            this.blockGridValue = {
+                                ...this._blockGridValue,
+                                layout: { ['Umbraco.BlockGrid']: this.#filterLayouts() }
+                            };
                             this.renderBlockPreview();
                         }
 
@@ -165,7 +172,7 @@ export class BlockGridPreviewCustomView extends BlockPreviewBaseElement<BlockGri
                             expose: exposes ?? [],
                             layout: { ['Umbraco.BlockGrid']: this.#filterLayouts() }
                         };
-                        this._blockContext.blockIndex = contents.findIndex(x => x.key === this._blockContext.contentUdi);
+                        this._blockContext.blockIndex = (contents ?? []).findIndex(x => x.key === this._blockContext.contentUdi);
                         if (!this._htmlMarkup && !this._isLoading) {
                             // Defer render if areas are expected but layoutAreas haven't arrived yet;
                             // observeBlockValue will trigger the render once layoutAreas are available.

--- a/src/Umbraco.Community.BlockPreview.UI/src/blockEditor/block-grid-preview.custom-view.element.ts
+++ b/src/Umbraco.Community.BlockPreview.UI/src/blockEditor/block-grid-preview.custom-view.element.ts
@@ -103,6 +103,7 @@ export class BlockGridPreviewCustomView extends BlockPreviewBaseElement<BlockGri
                     ]) => {
                         const prevColumnSpan = this._blockContext.layout?.columnSpan;
                         const prevRowSpan = this._blockContext.layout?.rowSpan;
+                        const prevLayoutAreas = this._blockContext.layoutAreas;
 
                         this._blockContext.contentUdi = contentUdi ?? '';
                         this._blockContext.settingsUdi = settingsUdi ?? '';
@@ -113,9 +114,14 @@ export class BlockGridPreviewCustomView extends BlockPreviewBaseElement<BlockGri
                         this._blockContext.layout = layout!;
                         this._blockContext.layoutAreas = layoutAreas;
 
-                        if (!this.#managerObserved) {
+                        if (!this.#managerObserved && this._blockContext.contentUdi) {
                             this.#managerObserved = true;
                             await this.#observeBlockPropertyValue();
+                        }
+
+                        // Re-render when layoutAreas first arrive for a block with areas
+                        if (this._htmlMarkup && !this._isLoading && !prevLayoutAreas && layoutAreas && (areas?.length ?? 0) > 0) {
+                            this.renderBlockPreview();
                         }
 
                         // Re-render when layout dimensions change (resize)
@@ -161,6 +167,11 @@ export class BlockGridPreviewCustomView extends BlockPreviewBaseElement<BlockGri
                         };
                         this._blockContext.blockIndex = contents.findIndex(x => x.key === this._blockContext.contentUdi);
                         if (!this._htmlMarkup && !this._isLoading) {
+                            // Defer render if areas are expected but layoutAreas haven't arrived yet;
+                            // observeBlockValue will trigger the render once layoutAreas are available.
+                            if ((this._blockContext.areas?.length ?? 0) > 0 && !this._blockContext.layoutAreas) {
+                                return;
+                            }
                             this.renderBlockPreview();
                         }
                     }


### PR DESCRIPTION
## Summary

Fixes #293

Resolves a timing regression introduced in 5.4.0 where layout blocks with Areas could render an incomplete preview (empty Areas) if `UMB_BLOCK_GRID_MANAGER_CONTEXT` fired before `layoutAreas` arrived from `UMB_BLOCK_GRID_ENTRY_CONTEXT`.

The issue: the manager context fires `renderBlockPreview()` guarded by `!this._htmlMarkup && !this._isLoading`. If it fires before `layoutAreas` are available, `#filterLayouts()` produces empty area items, the API returns a `BlockGridItem` with empty `Areas`, and `_htmlMarkup` is set. When `layoutAreas` later arrives in `observeBlockValue()`, nothing re-triggers the render because markup already exists.

**Two-part fix:**

- **`#observeBlockPropertyValue`**: defer the initial render when areas are configured (`areas.length > 0`) but `layoutAreas` have not arrived yet. The render is left to `observeBlockValue` once layout areas are available.
- **`observeBlockValue`**: trigger a re-render when `layoutAreas` transitions from `undefined` to a value, so any block that received an incomplete early render is refreshed with full area content.

Also applies the `contentUdi` guard (only subscribe to the manager context once `contentUdi` is non-empty) to prevent a parallel issue where an empty `contentUdi` on the first entry-context emission could lock the manager subscription into producing an empty `blockGridValue`.

## Test plan

- [ ] Add a layout block with one or more Areas to a Block Grid property
- [ ] Place child blocks inside the areas
- [ ] Verify the preview renders with populated area content on first load
- [ ] Verify resizing the block still re-renders correctly
- [ ] Verify blocks without areas are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)