### PR TITLE
fix: Prevent nested Block List previews rendering blank in side panel

### DIFF
--- a/src/Umbraco.Community.BlockPreview.UI/src/blockEditor/block-list-preview.custom-view.element.ts
+++ b/src/Umbraco.Community.BlockPreview.UI/src/blockEditor/block-list-preview.custom-view.element.ts
@@ -101,7 +101,10 @@ export class BlockListPreviewCustomView extends BlockPreviewBaseElement<BlockLis
                         this._blockContext.contentElementTypeAlias = contentElementTypeAlias ?? '';
                         this._blockContext.contentElementTypeKey = contentElementTypeKey ?? '';
 
-                        if (!this.#managerObserved) {
+                        // Only subscribe to manager context once contentUdi is known; subscribing with
+                        // an empty key causes the manager to filter contentData to [] on its first emit,
+                        // and the #managerObserved guard then blocks a corrective re-subscription.
+                        if (!this.#managerObserved && this._blockContext.contentUdi) {
                             this.#managerObserved = true;
                             await this.#observeBlockPropertyValue();
                         }


### PR DESCRIPTION
## Summary

Fixes #294

Resolves a regression introduced in 5.4.0 where block previews inside a Block List embedded on a content block showed no content when the parent block was edited in a side panel dialog.

**Root cause:** `UMB_BLOCK_LIST_ENTRY_CONTEXT` can emit `contentKey` as `undefined` on its first observable emission before the real UUID is available. The `#managerObserved` flag (introduced in 5.4.0 to prevent duplicate manager subscriptions) locked in the `UMB_BLOCK_LIST_MANAGER_CONTEXT` subscription at that point. The manager then fired with `contentUdi = ''` and filtered `contentData` to `[]`, causing the API to return empty markup. When `contentKey` later emitted its real value, `#managerObserved = true` blocked re-subscription — the manager had no new data to emit, so the preview stayed blank indefinitely.

**Fix:** only call `#observeBlockPropertyValue()` when `contentUdi` is non-empty, ensuring the manager context subscription is never established with an empty key.

## Test plan

- [ ] Create a content block that contains a Block List property with one or more blocks inside it
- [ ] Open the content block for editing in a side panel dialog
- [ ] Verify the nested Block List item previews render correctly
- [ ] Verify the same setup continues to work when viewed outside a side panel (normal Block List preview)
- [ ] Verify downgrading scenario: confirm this was broken in 5.4.0 without the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)