### PR TITLE
ci: Build frontend assets before packing in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,23 @@ jobs:
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
-  
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '22.12.0'
+        cache: 'npm'
+        cache-dependency-path: src/Umbraco.Community.BlockPreview.UI/package-lock.json
+
+    # Build the backoffice (Lit/Vite) assets into wwwroot before packing.
+    # The .csproj assumes the client assets are already built, so this must run first;
+    # otherwise the package ships a stale frontend bundle.
+    - name: Build frontend assets
+      working-directory: src/Umbraco.Community.BlockPreview.UI
+      run: |
+        npm ci
+        npm run build
+
     - name: Build project
       run: dotnet build src\Umbraco.Community.BlockPreview\Umbraco.Community.BlockPreview.csproj --configuration Release
 


### PR DESCRIPTION
## Problem
The release workflow only runs `dotnet build`, and the RCL `.csproj` *assumes the client assets are already built to wwwroot* (the `.esproj` sets `ShouldRunBuildScript`/`ShouldRunNpmInstall` to `false`). The compiled bundle is committed to the repo, and `git log` shows it was last rebuilt at `eda75ac "Set version to '5.4.0'"`.

As a result every release since 5.4.0 has shipped a **stale frontend bundle**. As reported on #293 and #300, 5.4.1's `index.js` is byte-identical (same SHA256) to 5.4.0's and is missing the merged 5.4.x source fixes (#293, #294, #297, …). The TypeScript fixes were merged but never recompiled/committed.

## Fix
Add a Node.js setup step (Node 22.12.0, matching `package.json` engines) plus `npm ci && npm run build` in the UI project **before** the `dotnet build`, so the package always contains a freshly compiled frontend and the bundle can't silently go stale again.

## Notes
- Uses `npm ci` against the tracked `package-lock.json`, with npm caching keyed on it.
- This complements #302 (the #300 RTE fix); together they ensure merged frontend fixes actually ship.
- Optional follow-up worth considering: stop committing the built `wwwroot` bundle and `.gitignore` it, now that CI builds it — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)