### PR TITLE
test: Migrate acceptance tests to @umbraco-cms/acceptance-test-helpers

### DIFF
--- a/tests/Umbraco.Community.BlockPreview.AcceptanceTests/lib/helpers/ApiHelpers.ts
+++ b/tests/Umbraco.Community.BlockPreview.AcceptanceTests/lib/helpers/ApiHelpers.ts
@@ -1,6 +1,6 @@
 import { Page } from "@playwright/test"
 import { umbracoConfig } from "../../umbraco.config";
-import { ApiHelpers as UmbracoApiHelpers } from "@umbraco/playwright-testhelpers";
+import { ApiHelpers as UmbracoApiHelpers } from "@umbraco-cms/acceptance-test-helpers";
 
 export class ApiHelpers {
   baseUrl: string = umbracoConfig.environment.baseUrl;

--- a/tests/Umbraco.Community.BlockPreview.AcceptanceTests/lib/helpers/UiHelpers.ts
+++ b/tests/Umbraco.Community.BlockPreview.AcceptanceTests/lib/helpers/UiHelpers.ts
@@ -1,5 +1,5 @@
 import { Page } from "@playwright/test"
-import { UiHelpers as UmbracoUiHelpers } from "@umbraco/playwright-testhelpers";
+import { UiHelpers as UmbracoUiHelpers } from "@umbraco-cms/acceptance-test-helpers";
 
 export class UiHelpers {
   page: Page;

--- a/tests/Umbraco.Community.BlockPreview.AcceptanceTests/lib/helpers/testExtension.ts
+++ b/tests/Umbraco.Community.BlockPreview.AcceptanceTests/lib/helpers/testExtension.ts
@@ -1,5 +1,5 @@
-import { test as base } from "@umbraco/playwright-testhelpers";
-import { UiHelpers } from "@umbraco/playwright-testhelpers";
+import { test as base } from "@umbraco-cms/acceptance-test-helpers";
+import { UiHelpers } from "@umbraco-cms/acceptance-test-helpers";
 import { ApiHelpers as BlockPreviewApiHelpers, UiHelpers as BlockPreviewUiHelpers } from ".";
 
 const test = base.extend<{ blockPreviewApi: BlockPreviewApiHelpers } & { blockPreviewUi: BlockPreviewUiHelpers }>({

--- a/tests/Umbraco.Community.BlockPreview.AcceptanceTests/package-lock.json
+++ b/tests/Umbraco.Community.BlockPreview.AcceptanceTests/package-lock.json
@@ -7,8 +7,8 @@
       "name": "acceptancetest",
       "hasInstallScript": true,
       "dependencies": {
+        "@umbraco-cms/acceptance-test-helpers": "^17.5.0",
         "@umbraco/json-models-builders": "^2.0.44",
-        "@umbraco/playwright-testhelpers": "^17.0.34",
         "dotenv": "^16.5.0"
       },
       "devDependencies": {
@@ -101,7 +101,6 @@
       "integrity": "sha512-c7VjBy/8ed0EVLNgaeS9Xxams1Tuv/WK/b4xXH3Qr4wjzYeJUtxOcoP8YdwNLavqKP8pGiuctjX2Z1Pwc4jMgQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=22.10.0"
       },
@@ -118,7 +117,6 @@
       "integrity": "sha512-BMnIuhVgNmSudadw1GcTsP18Yk5l8FrYrg/OSYNxz0D2E0vf4D5e4j5nUbuY8MU6p1vp7ev0xrfP6A/NWazkzQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jsdevtools/ono": "^7.1.3",
         "@types/json-schema": "^7.0.15",
@@ -168,16 +166,14 @@
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
       "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@lit/reactive-element": {
       "version": "2.1.2",
@@ -185,7 +181,6 @@
       "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.5.0"
       }
@@ -209,8 +204,8 @@
       "version": "1.56.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.1.tgz",
       "integrity": "sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==",
-      "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.56.1"
       },
@@ -226,8 +221,7 @@
       "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-3.0.0.tgz",
       "integrity": "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -398,7 +392,6 @@
       "integrity": "sha512-nPzraIx/f1cOUNqG1LSC0OTnEu3mudcN3jQVuyGh3dvdOnik7FUciJEVfHKnloAyeoijidEeiLpiGHInp2uREg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tiptap/core": "^3.6.2",
         "@tiptap/extension-blockquote": "^3.6.2",
@@ -451,7 +444,6 @@
       "integrity": "sha512-y3UfqY9KD5XwWz3ndiiJ089Ij2QKeiXy/g1/tlAN/F1AaWsnkHEHMLxCP1BIqmMpwsX7rZjMLN7G5Lp7c9682A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -466,7 +458,6 @@
       "integrity": "sha512-UZgb1d0XK4J/JRIZ7jW+s4S6KjuEDT2z1PPM6ugcgofgJkWQvRZelCPbmtSFd3kwsD+zr9UPVgTh9YIuGQ8t+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -481,7 +472,6 @@
       "integrity": "sha512-F9uNnqd0xkJbMmRxVI5RuVxwB9JaCH/xtRqOUNQZnRBt7IdAElCY+Dvb4hMCtiNv+enGM/RFGJuFHR9TxmI7rw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -496,7 +486,6 @@
       "integrity": "sha512-2kqqQIXBXj2Or+4qeY3WoE7msK+XaHKL6EKOcKlOP2BW8eYqNTPzNSL+PfBDQ3snA7ljZQkTs/j4GYDj90vR1A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -511,7 +500,6 @@
       "integrity": "sha512-b/2qR+tMn8MQb+eaFYgVk4qXnLNkkRYmwELQ8LEtEDQPxa5Vl7J3eu8+4OyoIFhZrNDZvvoEp80kHMCP8sI6rg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -527,7 +515,6 @@
       "integrity": "sha512-AOf0kHKSFO0ymjVgYSYDncRXTITdTcrj1tqxVazrmO60KNl1Rc2dAggDvIVTEBy5NvceF0scc7q3sE/5ZtVV7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -542,7 +529,6 @@
       "integrity": "sha512-sf3dEZXiLvsGqVK2maUIzXY6qtYYCvBumag7+VPTMGQ0D4hiZ1X/4ukt4+6VXDg5R2WP1CoIt/QvUetUjWNhbQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -557,7 +543,6 @@
       "integrity": "sha512-w7DACS4oSZaDWjz7gropZHPc9oXqC9yERZTcjWxyORuuIh1JFf0TRYspleK+OK28plK/IftojD/yUDn1MTRhvA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -572,7 +557,6 @@
       "integrity": "sha512-lAmQraYhPS5hafvCl74xDB5+bLuNwBKIEsVoim35I0sDJj5nTrfhaZgMJ91VamMvT+6FF5f1dvBlxBxAWa8jew==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -587,7 +571,6 @@
       "integrity": "sha512-uLpLlfyp086WYNOc0ekm1gIZNlEDfmzOhKzB0Hbyi6jDagTS+p9mxUNYeYOn9jPUxpFov43+Wm/4E24oY6B+TQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -602,7 +585,6 @@
       "integrity": "sha512-iqUHmgMGhMgYGwG6L/4JdelVQ5Mstb4qHcgTGd/4dkcUOepILvhdxajPle7OEdf9sRgjQO6uoAU5BVZVC26+ng==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -618,7 +600,6 @@
       "integrity": "sha512-6GffxOnS/tWyCbDkirWNZITiXRta9wrCmrfa4rh+v32wfaOL1RRQNyqo9qN6Wjyl1R42Js+yXTzTTzZsOaLMYA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -633,7 +614,6 @@
       "integrity": "sha512-HEGDJnnCPfr7KWu7Dsq+eRRe/mBCsv6DuI+7fhOCLDJjjKzNgrX2abbo/zG3D/4lCVFaVb+qawgJubgqXR/Smw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "linkifyjs": "^4.3.2"
       },
@@ -668,7 +648,6 @@
       "integrity": "sha512-VsSKuJz4/Tb6ZmFkXqWpDYkRzmaLTyE6dNSEpNmUpmZ32sMqo58mt11/huADNwfBFB0Ve7siH/VnFNIJYY3xvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -683,7 +662,6 @@
       "integrity": "sha512-bxgmAgA3RzBGA0GyTwS2CC1c+QjkJJq9hC+S6PSOWELGRiTbwDN3MANksFXLjntkTa0N5fOnL27vBHtMStURqw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -698,7 +676,6 @@
       "integrity": "sha512-cxGsINquwHYE1kmhAcLNLHAofmoDEG6jbesR5ybl7tU5JwtKVO7S/xZatll2DU1dsDAXWPWEeeMl4e/9svYjCg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -713,7 +690,6 @@
       "integrity": "sha512-xWa6gj82l5+AzdYyrSk9P4ynySaDzg/SlR1FarXE5yPXibYzpS95IWaVR0m2Qaz7Rrk+IiYOTGxGRxcHLOelNg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -728,7 +704,6 @@
       "integrity": "sha512-xYpabHsv7PccLUBQaP8AYiFCnYbx6P93RHPd0lgNwhdOjYFd931Zy38RyoxPHAgbYVmhf1iyx7lpuLtBnhS5dA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -743,7 +718,6 @@
       "integrity": "sha512-K95+SnbZy0h6hNFtfy23n8t/nOcTFEf69In9TSFVVmwn/Nwlke+IfiESAkqbt1/7sKJeegRXYO7WzFEmFl9Q/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -758,7 +732,6 @@
       "integrity": "sha512-800MGEWfG49j10wQzAFiW/ele1HT04MamcL8iyuPNu7ZbjbGN2yknvdrJlRy7hZlzIrVkZMr/1tz62KN33VHIw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -828,16 +801,14 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/linkify-it": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
       "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/markdown-it": {
       "version": "14.1.2",
@@ -845,7 +816,6 @@
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
@@ -856,8 +826,7 @@
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "20.19.32",
@@ -874,8 +843,19 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@umbraco-cms/acceptance-test-helpers": {
+      "version": "17.5.0",
+      "resolved": "https://www.myget.org/F/umbracoprereleases/npm/@umbraco-cms/acceptance-test-helpers/-/@umbraco-cms/acceptance-test-helpers-17.5.0.tgz",
+      "integrity": "sha1-Qwy6EHakhKTitzsyP+ZJOg7c9EE=",
       "license": "MIT",
-      "peer": true
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "peerDependencies": {
+        "@playwright/test": ">=1.56"
+      }
     },
     "node_modules/@umbraco-cms/backoffice": {
       "version": "17.0.0",
@@ -1014,7 +994,6 @@
       "integrity": "sha512-WM08j2cGcJcbXWS6Pb9FdhaKDz3+EUSuoxrsZoGkJBJMriZLv4gq9EcE5RIstUbT8JmDPQ7uT3SDT2gZWl07MQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-button-group": "1.16.0"
@@ -1026,7 +1005,6 @@
       "integrity": "sha512-1u6+hOLy5NrFh5/Z4Kp88y3Mhq+FYCZRwPb+5lSutm+aMy27dehRKkZqlbptWn/qocUCibDxQpruvu/UMtVQtg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1037,7 +1015,6 @@
       "integrity": "sha512-509UZzUSD/JhJEVLEpT5ltccHpEw8RxoZbG+hJeg23Oh3jNuRrKvuiyOut5c6JfjMdawHw6vPivVwjqCmbZG5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-avatar": "1.16.0",
         "@umbraco-ui/uui-base": "1.16.0"
@@ -1049,7 +1026,6 @@
       "integrity": "sha512-sHo71JOxxk0EufgYfCl9miuYgM1LDSnmtHedvDGs776htMFkLo3W/cFWgIXabAHZeSj4R5UWMGDNsugwv03R+w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1060,7 +1036,6 @@
       "integrity": "sha512-8i9bdcSrdR/4lWm0xetr3R3w3Rod3YVbIddHqbb3iVrr0TmPDTVA48tnOsJyQFAvTrh2LZjiETvEve7pBy4WQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "lit": ">=2.8.0"
       }
@@ -1071,7 +1046,6 @@
       "integrity": "sha512-IRU2z3GV+WzyjUvIMeErYeOE/0GyOpItsXxfmxsEENT/7qq4UMk28fIxY9IdDfI285WP0N3kezWkPBPlCKBcNQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1082,7 +1056,6 @@
       "integrity": "sha512-/Wgnv2jr6wKG436WNjBdGq6x+aExiZhZgLPnzrTcaevy85MM5pJZWgY1+aI+pJclgU6WtRMii2+C8MZL2Qmh0w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-css": "1.16.0"
@@ -1094,7 +1067,6 @@
       "integrity": "sha512-PuLcxG+3ZeSXKH3M0Kkh3eVYOEJPwLfg+6+b4UXxV/O9p0tUFbNPc8ciggL/1ZBXYXjsQnFTaOQWV4zGpnCnFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1105,7 +1077,6 @@
       "integrity": "sha512-0nTAx/GVOdGvlekkIxZp1nJs2E1DRzbdUnARl6RN5Oc40HowW9oO5oJvDIpoZcsWqkqWzFTQqVgE1z1PafKHZw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-icon-registry-essential": "1.16.0"
@@ -1117,7 +1088,6 @@
       "integrity": "sha512-CXjJzLbedqHtlza2zspSWNZCw5XhHV5QkPFzRI5Zd8FwFZop1/UgM2GQeSrMaWdfpznbWvfUqnvSYt9wYEubVg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-button": "1.16.0"
@@ -1129,7 +1099,6 @@
       "integrity": "sha512-ygici33P70SJqa2SSjdSVd8paSKqHwewKJMcyIF/IehDepnDP0ngSHWA23B/sEzJNJgq0Zngo9g3jlhZz6H6GA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1140,7 +1109,6 @@
       "integrity": "sha512-To9K/mYXLm4SGih3uA8/jbZd/ewWKVvYH6b26F5fvEDVT+X9fjJchKT7J/u0a4C7wghvVNT+os7H0rxS3yTXiQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1151,7 +1119,6 @@
       "integrity": "sha512-o/8vDLT03WnQsJKyD8r7PzxvhD3loRI7pL3tZU1BeSDcFAOZPPWIudQ/OwYeJnMI1iHkd2eTu0h22B/sXOfIIQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-checkbox": "1.16.0"
@@ -1163,7 +1130,6 @@
       "integrity": "sha512-Xpq/kB/ofSn067teaOyS4hEsEt/WUlrJ0opTFgkwHxsWg9rvMzUtg2nc2JGMoIqJ64/40Axcx0jmmchIDUcbsQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-card": "1.16.0"
@@ -1175,7 +1141,6 @@
       "integrity": "sha512-VPRDFrZSPLDGE3kAarW78dZHIFBhwXakyj7PM278tcXGdfSM7M9HsLXME6DhlleOYfSV07wHXm0UXKieqO7vgw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-card": "1.16.0",
@@ -1188,7 +1153,6 @@
       "integrity": "sha512-IHFCnXr4Bdpj/aUn+jpmlYx9L0FzeWTwt+cb29b4oP0cjIiVaJIrkOCSIl3SF8ncrKfMlTjlgBe0t0sP4mjeug==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-card": "1.16.0",
@@ -1202,7 +1166,6 @@
       "integrity": "sha512-Ne64+ssQrpP9zJvlJhH1Y5xlEDMW1lG17Orj6XH99iDtGdrnug9FjRE4vpNfAVRIb9P1pf7xNJtq2XqCJHvqOQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-avatar": "1.16.0",
         "@umbraco-ui/uui-base": "1.16.0",
@@ -1215,7 +1178,6 @@
       "integrity": "sha512-B3xNrwkQBwye9ydlrvnYfbJyiLqwQEbpldfaJnjLvlW9xVhOFps2NfeRyXcdsvruaIwjml7aB18GVYDCd/PSlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1226,7 +1188,6 @@
       "integrity": "sha512-4z8XrZ0InVArdHKO7L7uwAMwUwHyQKqSYShE74VHHWOibySciJ/zPx3hFO3eQ7EBL3Kj+4raun5Ah5jHUlDZwA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-boolean-input": "1.16.0",
@@ -1239,7 +1200,6 @@
       "integrity": "sha512-wiK9WNZWZ5yFd3ouTZOcoUSm+2iNZIFlGTaTScnG/DiLCBs6DUvdbSbVHueY1cGWbOx/R8N01kZBls1fk8kaHw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "colord": "^2.9.3"
@@ -1251,7 +1211,6 @@
       "integrity": "sha512-IilZw7Qn+2QF80OXktnoY1RI45ggl8o+QyF5a6zjd2gl5BfwAVx/uFCnpDfjH6LKtRw9WvuPKHQyM0/mfi5I4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-popover-container": "1.16.0",
@@ -1264,7 +1223,6 @@
       "integrity": "sha512-GDlAv+75efrOq9K/mZSKLwmc/ZG82hCaRMpWI4guKKvJhcukIcg7Bt/jQrDrtEGKCYvMJpNzbqZ41b+x23EQEg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1275,7 +1233,6 @@
       "integrity": "sha512-I+0iEkIGXzoDfLUj0duUJsdf71FC1EBqNzAH/X5noiWc+RZiAAw5EvXm7rZO69oDNOQMwt/yMCBLJQp2kYOQTA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-icon-registry-essential": "1.16.0",
@@ -1288,7 +1245,6 @@
       "integrity": "sha512-i58T2PRYzViBTo7OtJAGi5inVF8jxVYBmLL7nb3dpNjUFTZZufRKTr3AsVS7+pCGEogFmyNbcNztmmEMdU4ekA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-color-swatch": "1.16.0"
@@ -1300,7 +1256,6 @@
       "integrity": "sha512-zjeNG+7r5J4UgdeWh8Osktkjk/Uret5tu8mUtpp0Z6LIbxISUKEt9QlbjPPorxB3V0ENKUJ2c5KZZtpj7mLihQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-button": "1.16.0",
@@ -1317,7 +1272,6 @@
       "integrity": "sha512-gNFheYUtzMvQudvzoRhDgJk9zziFTxSyu92aYzyoyhh7M098gJfqU+fo7Teqqiuyb0NEiZPThcNrUT9MD2LD3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1339,7 +1293,6 @@
       "integrity": "sha512-dq+daSQKAIdsP+2QhM6HmU9Nr5VVzbxwQEYLVvAcmYcw4K98TVpP6AyHu5dPDP9vl4EBBXUrrZuXFjU+Mh8/xQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-css": "1.16.0"
@@ -1351,7 +1304,6 @@
       "integrity": "sha512-iRpmlzp1PAUpF6Ol2EWubdABIgpJE6QmBzaQONm3Mmwe1wLxMGp5+o33wHU9WSTh8kDrH/U5mWtua6Xtyf5JFA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1362,7 +1314,6 @@
       "integrity": "sha512-B3Zy6jlyK68ntaC4idv7fzd9NVyc4VVjn68DgkvnHR76Mp8zmOgT0g7K7/WM33IPw/n/ZfBhM1KEb+ry3i9/bg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-symbol-file-dropzone": "1.16.0"
@@ -1374,7 +1325,6 @@
       "integrity": "sha512-A+jych/xEUOssZjqWtW04nD1GcVOHnonTlPdrDaFh9PhwQAL0PREBbHZnkLJBS4z+HKWhsXOUeQ9ju0YAtbRuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-symbol-file": "1.16.0",
@@ -1388,7 +1338,6 @@
       "integrity": "sha512-mZVeqQtKirPHCES6TcTywELJi3raBgSKRt2XKCmHMDzclK9P11qPuOve335Jd8WPISsqbbcw4mIAGQpww7TxIg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1399,7 +1348,6 @@
       "integrity": "sha512-g1xYut9TQzAK1w0fijWyV2PlXJnaMw3MYgytvsEu3XD93hPut4XvkifM8Ja6YxpkRcKQpRRLa4WHroQ6OQY6LQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-form-validation-message": "1.16.0"
@@ -1411,7 +1359,6 @@
       "integrity": "sha512-55+WAkF02Im+bG1Xl1AABA7KIGXr5CZTgHbr3MsVVHJMtHv+gQZ04h+0TkvDzKZDSg8ucCXJKyD44Y4gOyS2oA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1422,7 +1369,6 @@
       "integrity": "sha512-x7HX9OnKOTgjbFbSSZ9Pk0+Lf6yo8ggLe6XTnPClu3ByN2fl9/QqshI5lx4oz5Adr/ItSj3zqnNB2JbyM56TLA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1433,7 +1379,6 @@
       "integrity": "sha512-o4l2bEYKdBcxAlSwEPO+cfnNvkGuGcZRyca026xvIz+nufbc/BBzskzS1UWIIjkFPu64rHEfxP/3KbSld64HYA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-icon": "1.16.0"
@@ -1445,7 +1390,6 @@
       "integrity": "sha512-HI4cnYhWpPtWFFgfEltjV6PPhOd3NQ58BhqfbCpRbwmHZUZ0OBzGRl4QgsPNKuhQqmcXene+Twfy8eoRk1/5nQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-icon-registry": "1.16.0"
@@ -1457,7 +1401,6 @@
       "integrity": "sha512-2Mp15ObjyAuRD3bOTs/zuUHqaaMiuDhmGsjeK8ViOrlSMnz/bVUme5scN1OMkNIryVHkENshC4NK7x6++X0/qw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1468,7 +1411,6 @@
       "integrity": "sha512-AxepSUJe0LmY4QmBA9UlzhZBBrVF+z88fFUWIH15PICFX0jfsPNIeiwQKlv7cN5pEInUh6qCRN64z8icf8fcdw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-action-bar": "1.16.0",
         "@umbraco-ui/uui-base": "1.16.0",
@@ -1484,7 +1426,6 @@
       "integrity": "sha512-FTLj/2s+VImEtKe1GPSkAC2pmTabz5cGzvaFB/7xrJj/1evVxXGu8qQyyL96WoDe+RAmBNYfrnGx7OUSVhEyRw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-button": "1.16.0",
@@ -1498,7 +1439,6 @@
       "integrity": "sha512-0gg8nAVHsMYlQscG76PN4L8ha3CpW15crlzgj4TMaW24OIgZ0khV18ZImJ5n9wv/zrq8LsrwJTyZ5/a/soaKyQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-icon-registry-essential": "1.16.0",
@@ -1511,7 +1451,6 @@
       "integrity": "sha512-z9wlhONxtwkUCkPEKqt/vSH1qOTwHCIM2Cj/DQ21+bfWcywUR7cAp0vRveapymDn4eHSuRra5lrG7xgLYsYuVg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1522,7 +1461,6 @@
       "integrity": "sha512-1vQAKUR+frDEth8AMLS5KKpVK2LHD61lWUG95yMypF5C2+YBmzXb70QEakOubTMsmLnYcU3hfORfA5Wp9cYPnw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1533,7 +1471,6 @@
       "integrity": "sha512-wcFUljPcrAR6YYuj5XLmtMpZBvzTBcakr9p+vISOoC3ta8UlE+OOLiQn+XYzTuV/ZbM77EHh5EEyiO5L45fQew==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1544,7 +1481,6 @@
       "integrity": "sha512-xh6RCS60WPWPzf0dAA+lTTt0rF8hksQsYBLwITBsR/5k3qswhT9Ctu/2LvqUXoLPyEFTecA4fyqZK+NzhjZrdQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1555,7 +1491,6 @@
       "integrity": "sha512-jawUHoiUwwZkp5YOLFlF00WvZ5yPowfbi22TufSyfls5hMajJM/p21IrCTStrc4ZimqyheaaYe/AqdGLDimfSQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1566,7 +1501,6 @@
       "integrity": "sha512-tyyuehJSj1BU/EEsQ1LHN8eg+gcAKCzqGMwwpepEtKZDd7p1/Ioq1KEn2e20UOihXab5rFv5UNEWSeyEYRqL4Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-loader-bar": "1.16.0",
@@ -1579,7 +1513,6 @@
       "integrity": "sha512-hqlXHjlGxEWEeX5c7W0xNlH25xDbb8vdgBIfYGUkBfrYrgO3j+AJ/B7OvmgWJogFTOHRRaPUvKDi8DkDnDH4zw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1590,7 +1523,6 @@
       "integrity": "sha512-bZQl5BwiYHSQqc0bjajQbu8ZX+z4qe56t6PiT6s+VUj6huXOOrT72hpY2u+ZE22sAWPaIu42Kg9ulxNV2pulRw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-button": "1.16.0",
@@ -1603,7 +1535,6 @@
       "integrity": "sha512-ZtHPdupRjxwuSHmY5EiiGtZMBi5UsAyHOucn5SxMgdyHT7bRxrV1ebCblDu4eikXg/xx1nTDSFmmW4rXLftULg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1614,7 +1545,6 @@
       "integrity": "sha512-3N8M4hPQFcthVfqfhdCMX9B4q+0sG2zizoQf2SvDoLp3GAqND2zw2cwYClMy8HJh3XH9JINljz3PliyKMXVaXw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1625,7 +1555,6 @@
       "integrity": "sha512-GE/ZW5Rq82LgVbArppIG8Zkd6QFmCTGEV4Iq5V4KPOl5iSVu2yuYJCDD77aR1LgclSjk1YiJ1/oge94RXqAtOA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1636,7 +1565,6 @@
       "integrity": "sha512-r3JmVGeGzCzUPEKdOzxunsoRO2q7zGoI5eUtrSXdLSFiR2klW+hti/fjvqvruqzRZRjB0oumbJfMU4IxHcZblw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1647,7 +1575,6 @@
       "integrity": "sha512-9qx3Qj8kmIyHRbcVNexWTs4eGjsxs9FkjP7czpC1P0CPJFIt8LzeB6gBwSS/nJGuIo06RQ42qOc8FOza2tN+jA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1658,7 +1585,6 @@
       "integrity": "sha512-+ptIzEx8a3Oy4XL6TFibR5Q5lWDpjCSPCN2DgIitBj9C0R8zWbBo8sxj2iLGP4RsBiHeTUbDiJlSY1seo2E+Ew==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1669,7 +1595,6 @@
       "integrity": "sha512-MRxTX8CDvquBkkEGfpPsX5ttnsPGJ+Kb1KfR+arueXazQ9XfqyoFCAWWXfOxGL7A5txGTMnKEfj59dyLeCec5Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1680,7 +1605,6 @@
       "integrity": "sha512-4IO02sBoJLlErxXPeFBXTtOZzQeFbCf0flpHCjMZ+vWKZ6GarlUMSvbXjuzh5SBEveVxWYhjd7Z7lP+g2pOHGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-icon": "1.16.0",
@@ -1693,7 +1617,6 @@
       "integrity": "sha512-0yRbSOoKl5gSAnRIEXTdFYlrt4NSvuLx1+TuQyeE/CV8lfObGqM1+y+ueX0AgPuNTXAf7j5rPIRLsVJHfCs2MA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-ref-node": "1.16.0"
@@ -1705,7 +1628,6 @@
       "integrity": "sha512-ORBBH6GRq5VFTNZd++f7dXCLJdgEGhtd1rcdbxjqtYnJrKeJ0dBNhJkF3kLoSQ1MiOG1SHOckGUZr5nLMUhc/w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-ref-node": "1.16.0"
@@ -1717,7 +1639,6 @@
       "integrity": "sha512-Z3m2toN+LcZOXVe/3q6d9kyPyWXR9l8CJSk1NkEn/ojMYrRzmo5AW92xWw/twHV8bRsEBDSeKxSKMVGnJVyUHg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-ref-node": "1.16.0"
@@ -1729,7 +1650,6 @@
       "integrity": "sha512-v9m/e5krM1IPV1gI/9dqVKgGYthyWXDlq9lCdiigpTfzv7xkCF+LPEmVksDZaKD498gGYtbYJReCXUxCwjxGTA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-ref-node": "1.16.0"
@@ -1741,7 +1661,6 @@
       "integrity": "sha512-6z/oa4qX+L746nEet0EDx88roSTcfjnzQj5fH2ebW4WJ6Arh/b+QmPOE3UEn2QiqjJLovkIhNcwf0m9PM7rSSw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-ref-node": "1.16.0"
@@ -1753,7 +1672,6 @@
       "integrity": "sha512-TdYTh+1pZfOFD9dKBtti1oDF1Pk5Bp3PyNKf1JLtcPm8uD/UPDxRkIYV7It04E6P7VWusdRabdlv/q9PRimA5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-ref-node": "1.16.0"
@@ -1765,7 +1683,6 @@
       "integrity": "sha512-+ArdQO09sGB1t24rzi+rk3YsZZayZRr5aKny53qAKkklJg0IDCJ+Vme9DvuSk0HBEzCe0YF313lv5mYjxFwCzQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1776,7 +1693,6 @@
       "integrity": "sha512-/tXty/HSqTAwnqsmLIsDc8LsE7XW0pZaCu+B/Ov3FjYQSb312AqXBwP7Z59gAbh2M0XvI3qxcA/sLcFndqN1oA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1787,7 +1703,6 @@
       "integrity": "sha512-zWXe+SOzXbhO2tN+DnVXbefEWICZ+FHCR1EGldZdab3hQO53M4HOKqTBd1akE6iFli7FN4BOnELGjnMnupaqvw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1798,7 +1713,6 @@
       "integrity": "sha512-w9i+deCNhZ3TzwgMx2glGbpyvXQHyP0kCmuazXi4cYGFtEXM48d1OScm/PrGs04ICNuqEIwY/IZ+PGfRSI27lA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1809,7 +1723,6 @@
       "integrity": "sha512-8iyZCjVAFvKrz1m0RTPiZmbXYLyb0Gs2blgg/uPyBzpNvptnXgx29UVTzITu2xvqVvwvureFNcxqeYL5WsfCiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1820,7 +1733,6 @@
       "integrity": "sha512-d9VJQTEBKwTHrvgPAXLgG4m3quDbxg1EhJhE03cxZr/yrZ81I2TD3wd4Pt9uxL1kvpZ95mP2vDfbedUfm/0fww==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1831,7 +1743,6 @@
       "integrity": "sha512-PMm3lTtIAwyE+6Erz2xiamKPuHhqazk2aWHgqC9fzD/0ROlWQMYEP3M99onp8/YCIprzfvXPuH6ofs6kq9bY7Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1842,7 +1753,6 @@
       "integrity": "sha512-vATvt+AcfP9pZxh99DKaq/wrD60EN4nvdtZ/BpHH6MOhX32T8LEboh57XisHmGamUSGbm2jQhASJTt+7cvjI/w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1853,7 +1763,6 @@
       "integrity": "sha512-mAFnPdUzlddfdLMTkBetCTnShV3QTWMpjqaG5fCaauizWmReye/rCwDur51URL+VkWMIWp29JvfYIIm8Yk+ZGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1864,7 +1773,6 @@
       "integrity": "sha512-WBd/6SNLVP04WU0Em8Uc9/GXsKYpYdHzlEjh7w5oU1TfbDEiNq1lXkOlpuvL79wJtd/2fTKfqui02+i79KU7ig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1875,7 +1783,6 @@
       "integrity": "sha512-hBhvUmkPc5WgFcjKDm6jtQq2USCO+ysveJRI1oJReiZkyj06IjU5mYddUL/sOG4L7Ud6OFqVbY002Uw+j9QpYQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1886,7 +1793,6 @@
       "integrity": "sha512-cVq84cwbgOvjoTn+5L4eboXPGkYdcIkWm/oU8GxbR1OdUtgPtqnPwB51Ial6ylyIHqvYbCDmDMzrjjnrB/qfJw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1897,7 +1803,6 @@
       "integrity": "sha512-FBToNg7zgB9paPQPbpnuC66KAMz3iR/F+tmLhjWnwGSit7ubFspPqgrReSjVS9zdd+zbi7wTJOcmKnHmoyP1bw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-button": "1.16.0",
@@ -1911,7 +1816,6 @@
       "integrity": "sha512-u6pBhOEvXYvUNTxNO1Ftcnflii1CmeuvNAXxuIj8TMmTXGXWmap0W5cGmzlEbbLAMGLv56AJXdz3rKDrWNyTvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1922,7 +1826,6 @@
       "integrity": "sha512-xTO4i/m4Q7wEeaxmV1bxT5e1bnLRJ1CoG+awe2FKGq6xw2ZHgksSrm6j3Ddbm5WzV019hIeVl22bnVQ5gOwrww==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1933,7 +1836,6 @@
       "integrity": "sha512-ziOJ4uyQpIVCBym2RlZFJOuOb2feNr1sP0RxUjhXToREJdG2MH2bgYyy76K0OCZ7a+JKCsHdaBH4XquXIH93VA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-button": "1.16.0",
@@ -1948,7 +1850,6 @@
       "integrity": "sha512-8HwiYkOA8Rsxpp2ZGsDTq16odV7Ja7xAAp/0BcdosdQYn6L4KUbSimulGaP/Q1KATUCFT7QflQiv0gnwuPpngQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-toast-notification": "1.16.0"
@@ -1960,7 +1861,6 @@
       "integrity": "sha512-OTrTAGUPe8EQRuCWJD8GsCw8MfNJuXx50NLZLDDZKzw3TlDiWMxUD0c4l6zOMy4ih7n7D5sMekHqonW5x6lVuA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-css": "1.16.0"
@@ -1972,7 +1872,6 @@
       "integrity": "sha512-opFdwN0LlH6l1xlzEv+e9tvLgySXRr4Ug5LBlzNRJKC/WhinUSq/okerIVyUJgk4oKdZV/y7T7u/07LiekCTAA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-boolean-input": "1.16.0"
@@ -1984,7 +1883,6 @@
       "integrity": "sha512-fqcv9gZUey2FkE2IRWuDgpk+D5XCdC1gnmQ4bIlAs03cMhl2BWP7U04Zo1u78jcWCbjxfnp60rfE6h11ukd5sg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1998,23 +1896,12 @@
         "camelize": "^1.0.1"
       }
     },
-    "node_modules/@umbraco/playwright-testhelpers": {
-      "version": "17.0.34",
-      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-17.0.34.tgz",
-      "integrity": "sha512-p9x1TRCqKCiYfm1gUndY7hEgtwjaVc05o1HHQ/wVuWQIP8l0ho1Shf5u7D4yiFQtXbQCy8746gWGSgaaTqQGxA==",
-      "license": "MIT",
-      "dependencies": {
-        "@umbraco/json-models-builders": "2.0.45",
-        "node-fetch": "^2.6.7"
-      }
-    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "event-target-shim": "^5.0.0"
       },
@@ -2028,7 +1915,6 @@
       "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -2038,8 +1924,7 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
-      "license": "Python-2.0",
-      "peer": true
+      "license": "Python-2.0"
     },
     "node_modules/async": {
       "version": "3.2.3",
@@ -2073,7 +1958,6 @@
       "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "run-applescript": "^7.0.0"
       },
@@ -2090,7 +1974,6 @@
       "integrity": "sha512-K9ZkuyeJQeqLEyqldbYLG3wjqwpw4BVaAqvmxq3GYKK0b1A/yYQdIcJxkzAOWcNVWhJpRXAPfZFueekiY/L8Dw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.3",
         "confbox": "^0.2.2",
@@ -2120,7 +2003,6 @@
       "integrity": "sha512-mudtfb4zRB4bVvdj0xRo+e6duH1csJRM8IukBqfTRvHotn9+LBXB8ynAidP9zHqoRC/fsllXgk4kCKlR21fIhw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2157,7 +2039,6 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -2174,7 +2055,6 @@
       "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "consola": "^3.2.3"
       }
@@ -2185,7 +2065,6 @@
       "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "color-support": "bin.js"
       }
@@ -2195,8 +2074,7 @@
       "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
       "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/colors": {
       "version": "1.0.3",
@@ -2227,7 +2105,6 @@
       "integrity": "sha512-oPYleIY8wmTVzkvQq10AEok6YcTC4sRUBl8F9gVuwchGVUCTbl/vhLTaQqutuuySYOsu8YTgV+OxKc/8Yvx+mQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2237,8 +2114,7 @@
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
       "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/consola": {
       "version": "3.4.2",
@@ -2246,7 +2122,6 @@
       "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
       }
@@ -2256,8 +2131,7 @@
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/cycle": {
       "version": "1.0.3",
@@ -2274,7 +2148,6 @@
       "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bundle-name": "^4.1.0",
         "default-browser-id": "^5.0.0"
@@ -2292,7 +2165,6 @@
       "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2306,7 +2178,6 @@
       "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2319,8 +2190,7 @@
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
       "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -2337,8 +2207,7 @@
       "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
       "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/diff": {
       "version": "7.0.0",
@@ -2403,7 +2272,6 @@
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -2466,7 +2334,6 @@
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2480,7 +2347,6 @@
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -2491,7 +2357,6 @@
       "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       }
@@ -2501,8 +2366,7 @@
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
       "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/eyes": {
       "version": "0.1.8",
@@ -2519,7 +2383,6 @@
       "integrity": "sha512-h9AgfjURuCgA2+2ISl8GbavpUdR+WGAM2McW/ovn4tVccegp8ZqCKWSBR8uRdM8dDNlx5WdKRWxBYUwteLDCNQ==",
       "dev": true,
       "license": "Unlicense",
-      "peer": true,
       "dependencies": {
         "set-cookie-parser": "^2.4.8",
         "tough-cookie": "^4.0.0"
@@ -2567,7 +2430,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2633,7 +2495,6 @@
       "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "citty": "^0.1.6",
         "consola": "^3.4.0",
@@ -2665,7 +2526,6 @@
       "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.2",
@@ -2730,7 +2590,6 @@
       "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "is-docker": "cli.js"
       },
@@ -2747,7 +2606,6 @@
       "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-docker": "^3.0.0"
       },
@@ -2767,7 +2625,6 @@
       "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-inside-container": "^1.0.0"
       },
@@ -2791,7 +2648,6 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -2821,7 +2677,6 @@
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -2835,7 +2690,6 @@
       "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "uc.micro": "^2.0.0"
       }
@@ -2845,8 +2699,7 @@
       "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
       "integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lit": {
       "version": "3.3.2",
@@ -2867,7 +2720,6 @@
       "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.5.0",
         "@lit/reactive-element": "^2.1.0",
@@ -2880,7 +2732,6 @@
       "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
       }
@@ -2909,7 +2760,6 @@
       "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
@@ -2951,8 +2801,7 @@
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
@@ -2993,7 +2842,6 @@
       "integrity": "sha512-hx45SEUoLatgWxHKCmlLJH81xBo0uXP4sRkESUpmDQevfi+e7K1VuiSprK6UpQ8u4zOcKNiH0pMvHvlMWA/4cw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dompurify": "3.1.7",
         "marked": "14.0.0"
@@ -3004,8 +2852,7 @@
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.7.tgz",
       "integrity": "sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==",
       "dev": true,
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "peer": true
+      "license": "(MPL-2.0 OR Apache-2.0)"
     },
     "node_modules/monaco-editor/node_modules/marked": {
       "version": "14.0.0",
@@ -3013,7 +2860,6 @@
       "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -3033,13 +2879,13 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -3061,8 +2907,7 @@
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
       "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/nypm": {
       "version": "0.6.5",
@@ -3070,7 +2915,6 @@
       "integrity": "sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "citty": "^0.2.0",
         "pathe": "^2.0.3",
@@ -3088,16 +2932,14 @@
       "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.0.tgz",
       "integrity": "sha512-8csy5IBFI2ex2hTVpaHN2j+LNE199AgiI7y4dMintrr8i0lQiFn+0AWMZrWdHKIgMOer65f8IThysYhoReqjWA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ohash": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
       "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/open": {
       "version": "10.1.2",
@@ -3105,7 +2947,6 @@
       "integrity": "sha512-cxN6aIDPz6rm8hbebcP7vrQNhvRcveZoJU72Y7vskh4oIm+BZwBECnx5nTmrlres1Qapvx27Qo1Auukpf8PKXw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "default-browser": "^5.2.1",
         "define-lazy-prop": "^3.0.0",
@@ -3124,24 +2965,21 @@
       "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
       "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/perfect-debounce": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
       "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/pkg-types": {
       "version": "2.3.0",
@@ -3149,7 +2987,6 @@
       "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "confbox": "^0.2.2",
         "exsolve": "^1.0.7",
@@ -3160,7 +2997,6 @@
       "version": "1.56.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
       "integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.56.1"
@@ -3179,7 +3015,6 @@
       "version": "1.56.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
       "integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -3211,7 +3046,6 @@
       "integrity": "sha512-j0kORIBm8ayJNl3zQvD1TTPHJX3g042et6y/KQhZhnPrruO8exkTgG8X+NRpj7kIyMMEx74Xb3DyMIBtO0IKkQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-transform": "^1.0.0"
       }
@@ -3222,7 +3056,6 @@
       "integrity": "sha512-4SnynYR9TTYaQVXd/ieUvsVV4PDMBzrq2xPUWutHivDuOshZXqQ5rGbZM84HEaXKbLdItse7weMGOUdDVcLKEQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-state": "^1.0.0"
       }
@@ -3233,7 +3066,6 @@
       "integrity": "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-state": "^1.0.0",
@@ -3246,7 +3078,6 @@
       "integrity": "sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-state": "^1.0.0",
         "prosemirror-transform": "^1.1.0",
@@ -3259,7 +3090,6 @@
       "integrity": "sha512-z00qvurSdCEWUIulij/isHaqu4uLS8r/Fi61IbjdIPJEonQgggbJsLnstW7Lgdk4zQ68/yr6B6bf7sJXowIgdQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-keymap": "^1.0.0",
         "prosemirror-model": "^1.0.0",
@@ -3273,7 +3103,6 @@
       "integrity": "sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-state": "^1.2.2",
         "prosemirror-transform": "^1.0.0",
@@ -3287,7 +3116,6 @@
       "integrity": "sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-state": "^1.0.0",
         "prosemirror-transform": "^1.0.0"
@@ -3299,7 +3127,6 @@
       "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-state": "^1.0.0",
         "w3c-keyname": "^2.2.0"
@@ -3311,7 +3138,6 @@
       "integrity": "sha512-D98dm4cQ3Hs6EmjK500TdAOew4Z03EV71ajEFiWra3Upr7diytJsjF4mPV2dW+eK5uNectiRj0xFxYI9NLXDbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/markdown-it": "^14.0.0",
         "markdown-it": "^14.0.0",
@@ -3324,7 +3150,6 @@
       "integrity": "sha512-qwXzynnpBIeg1D7BAtjOusR+81xCp53j7iWu/IargiRZqRjGIlQuu1f3jFi+ehrHhWMLoyOQTSRx/IWZJqOYtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "crelt": "^1.0.0",
         "prosemirror-commands": "^1.0.0",
@@ -3349,7 +3174,6 @@
       "integrity": "sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.25.0"
       }
@@ -3360,7 +3184,6 @@
       "integrity": "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-state": "^1.0.0",
@@ -3386,7 +3209,6 @@
       "integrity": "sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-keymap": "^1.2.3",
         "prosemirror-model": "^1.25.4",
@@ -3401,7 +3223,6 @@
       "integrity": "sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@remirror/core-constants": "3.0.0",
         "escape-string-regexp": "^4.0.0"
@@ -3418,7 +3239,6 @@
       "integrity": "sha512-4I7Ce4KpygXb9bkiPS3hTEk4dSHorfRw8uI0pE8IhxlK2GXsqv5tIA7JUSxtSu7u8APVOTtbUBxTmnHIxVkIJw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.21.0"
       }
@@ -3449,7 +3269,6 @@
       "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "punycode": "^2.3.1"
       },
@@ -3463,7 +3282,6 @@
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -3474,7 +3292,6 @@
       "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -3484,8 +3301,7 @@
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/rc9": {
       "version": "2.1.2",
@@ -3493,7 +3309,6 @@
       "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "defu": "^6.1.4",
         "destr": "^2.0.3"
@@ -3518,7 +3333,6 @@
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 14.18.0"
       },
@@ -3532,8 +3346,7 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/revalidator": {
       "version": "0.1.8",
@@ -3550,8 +3363,7 @@
       "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
       "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/run-applescript": {
       "version": "7.1.0",
@@ -3559,7 +3371,6 @@
       "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -3573,6 +3384,7 @@
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -3583,7 +3395,6 @@
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -3596,8 +3407,7 @@
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -3605,7 +3415,6 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3626,7 +3435,6 @@
       "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3637,7 +3445,6 @@
       "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
@@ -3652,13 +3459,13 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/typescript": {
@@ -3667,6 +3474,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3680,8 +3488,7 @@
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/uglify-js": {
       "version": "3.19.3",
@@ -3690,7 +3497,6 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
-      "peer": true,
       "bin": {
         "uglifyjs": "bin/uglifyjs"
       },
@@ -3711,7 +3517,6 @@
       "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -3722,7 +3527,6 @@
       "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -3748,8 +3552,7 @@
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/wait-on": {
       "version": "8.0.5",
@@ -3775,12 +3578,14 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
@@ -3820,8 +3625,7 @@
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ws": {
       "version": "7.5.10",
@@ -3829,7 +3633,6 @@
       "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8.3.0"
       },

--- a/tests/Umbraco.Community.BlockPreview.AcceptanceTests/package.json
+++ b/tests/Umbraco.Community.BlockPreview.AcceptanceTests/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@umbraco/json-models-builders": "^2.0.44",
-    "@umbraco/playwright-testhelpers": "^17.0.34",
+    "@umbraco-cms/acceptance-test-helpers": "^17.5.0",
     "dotenv": "^16.5.0"
   }
 }

--- a/tests/Umbraco.Community.BlockPreview.AcceptanceTests/tests/DefaultConfig/BlockPreview/block-preview.spec.ts
+++ b/tests/Umbraco.Community.BlockPreview.AcceptanceTests/tests/DefaultConfig/BlockPreview/block-preview.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from "@playwright/test";
-import { ConstantHelper } from "@umbraco/playwright-testhelpers";
+import { ConstantHelper } from "@umbraco-cms/acceptance-test-helpers";
 import { test } from "../../../lib/index";
 
 /**

--- a/tests/Umbraco.Community.BlockPreview.AcceptanceTests/tests/auth.setup.ts
+++ b/tests/Umbraco.Community.BlockPreview.AcceptanceTests/tests/auth.setup.ts
@@ -1,6 +1,6 @@
 import {test as setup} from '@playwright/test';
 import {STORAGE_STATE} from '../playwright.config';
-import {ConstantHelper, UiHelpers} from "@umbraco/playwright-testhelpers";
+import {ConstantHelper, UiHelpers} from "@umbraco-cms/acceptance-test-helpers";
 
 setup('authenticate', async ({page}) => {
   const umbracoUi = new UiHelpers(page);
@@ -8,8 +8,8 @@ setup('authenticate', async ({page}) => {
   await umbracoUi.goToBackOffice();
   // Wait for login form to be ready
   await page.locator('[name="username"]').waitFor({state: 'visible', timeout: 30000});
-  await umbracoUi.login.enterEmail(process.env.UMBRACO_USER_LOGIN);
-  await umbracoUi.login.enterPassword(process.env.UMBRACO_USER_PASSWORD);
+  await umbracoUi.login.enterEmail(process.env.UMBRACO_USER_LOGIN!);
+  await umbracoUi.login.enterPassword(process.env.UMBRACO_USER_PASSWORD!);
   await umbracoUi.login.clickLoginButton();
   // Wait for backoffice to load after login
   await page.getByTestId('section-links').waitFor({state: 'visible', timeout: 30000});


### PR DESCRIPTION
## Problem
The Playwright acceptance suite fails in **every** test's `beforeEach` (the `umbracoApi` fixture → `isLoginStateValid()` → `getLocalStorageAuthToken()`):

```
TypeError: Cannot read properties of undefined (reading 'value')
```

**Root cause:** the project depends on the **deprecated** `@umbraco/playwright-testhelpers@^17.0.34`. Its `getLocalStorageAuthToken()` reads the auth token from the localStorage key `umb:userAuthTokenResponse`. Umbraco 17.5's backoffice switched to **cookie-based auth**, so that key no longer exists — the saved storage state holds only `umb:appLanguage` plus auth cookies — and the helper throws.

The package is deprecated upstream:
> *"The helpers have been moved into the Umbraco CMS acceptance test project. Please use `@umbraco-cms/acceptance-test-helpers` instead. Versioning now follows CMS versions…"*

The replacement's `isLoginStateValid()` was rewritten to rely on cookies (no localStorage token read), matching Umbraco 17.5. This is the same package the **Umbraco Forms** acceptance tests use.

## Change
- Swap `@umbraco/playwright-testhelpers@^17.0.34` → `@umbraco-cms/acceptance-test-helpers@^17.5.0` (matching the 17.5.0 test site).
- Update the five import sites (same exported names: `ApiHelpers`, `UiHelpers`, `ConstantHelper`, `test`).
- Add non-null assertions for the env credentials in `auth.setup.ts` (the new helper's stricter login signatures require `string`).

## Verification
With the running Umbraco 17.5 test site, the full `DefaultConfig` suite now authenticates and passes:

```
[setup] authenticate
[DefaultConfig] Can navigate to the content section @smoke
[DefaultConfig] Block Grid page renders block previews @smoke
[DefaultConfig] Block List page renders block previews @smoke
  4 passed
```

## Note for merge ordering
This PR and #302 (the #300 RTE fix) both touch `block-preview.spec.ts` — this PR changes the import line; #302 adds the RTE regression test (with the old import, to stay internally consistent on its own branch). Expect a **trivial one-line conflict** on the import when both land: keep `@umbraco-cms/acceptance-test-helpers`. I verified the combined result (this migration + #302's fix + the RTE test) passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)