### PR TITLE
fix: resolve documentTypeUnique for previews nested in blocks

### DIFF
--- a/docs/advanced-customization.md
+++ b/docs/advanced-customization.md
@@ -27,8 +27,11 @@ using Umbraco.Community.BlockPreview.Enums;
 public class CustomBlockPreviewService : BlockPreviewService
 {
     private readonly IRazorViewEngine _razorViewEngine;
-    private readonly IUserPreferenceService _userPreferenceService;
 
+    // The first nine parameters are the dependencies of the base BlockPreviewService.
+    // You must accept them and forward them to the base constructor.
+    // Add any dependencies of your own after them — here IRazorViewEngine, which the
+    // GetViewResult override below uses to resolve a themed view.
     public CustomBlockPreviewService(
         IPublishedModelFactory publishedModelFactory,
         BlockEditorConverter blockEditorConverter,
@@ -39,14 +42,12 @@ public class CustomBlockPreviewService : BlockPreviewService
         IBlockDataConverter blockDataConverter,
         IBlockTypeCacheService blockTypeCacheService,
         IBlockPreviewViewResolver viewResolver,
-        IRazorViewEngine razorViewEngine,
-        IUserPreferenceService userPreferenceService)
+        IRazorViewEngine razorViewEngine)
         : base(publishedModelFactory, blockEditorConverter, options, jsonSerializer,
                blockModelFactory, blockViewRenderer, blockDataConverter,
                blockTypeCacheService, viewResolver)
     {
         _razorViewEngine = razorViewEngine;
-        _userPreferenceService = userPreferenceService;
     }
 
     // Override to provide dynamic stylesheet paths
@@ -103,9 +104,9 @@ public class CustomBlockPreviewService : BlockPreviewService
             viewData["theme"] = theme;
         }
 
-        // The async version lets you perform async operations like database lookups or API calls
-        var userPreferences = await _userPreferenceService.GetPreferencesAsync();
-        viewData["preferences"] = userPreferences;
+        // Because this override is async, you can await your own work here —
+        // for example a database lookup or API call to fetch additional view data,
+        // using any services you injected via the constructor.
 
         return viewData;
     }
@@ -127,7 +128,6 @@ You can access custom ViewData in your Razor views:
 
 @{
     var theme = ViewData["theme"] as string;
-    var preferences = ViewData["preferences"];
 }
 
 <div class="block block--@theme">

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,6 +32,15 @@ builder.AddBlockPreview(options =>
       ViewLocations = [],
       Stylesheets = []
   };
+
+  options.SingleBlock = new()
+  {
+      Enabled = true,
+      ContentTypes = [],
+      IgnoredContentTypes = [],
+      ViewLocations = [],
+      Stylesheets = []
+  };
 })
 ```
 
@@ -58,6 +67,13 @@ builder.AddBlockPreview(options =>
       "IgnoredContentTypes": [],
       "ViewLocations": [],
       "Stylesheets": []
+    },
+    "SingleBlock": {
+      "Enabled": false,
+      "ContentTypes": [],
+      "IgnoredContentTypes": [],
+      "ViewLocations": [],
+      "Stylesheets": []
     }
   }
 }
@@ -71,6 +87,7 @@ builder.AddBlockPreview(options =>
 | BlockGrid | [`BlockTypeSettings`](#blocktypesettings) | Configure settings for the Block Grid previews |
 | BlockList | [`BlockTypeSettings`](#blocktypesettings) | Configure settings for the Block List previews |
 | RichText  | [`BlockTypeSettings`](#blocktypesettings) | Configure settings for the Rich Text previews  |
+| SingleBlock | [`BlockTypeSettings`](#blocktypesettings) | Configure settings for the single Block property editor previews. Views default to the Block List Components path (`/Views/Partials/blocklist/Components/{0}.cshtml`). |
 
 ### BlockTypeSettings
 | Property            | Type                     | Description                                                                                                                                                                                                   |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -48,7 +48,7 @@ You will also need to use `@await Html.GetPreviewBlockGridItemAreasHtmlAsync(Mod
     style="background-color: #@backgroundColor"
     @(noBackgroundColor ? "nobackgroundcolor" : null)
     @(hasBrightContrast ? "bright-contrast" : null)>
-+   await Html.GetPreviewBlockGridItemAreasHtmlAsync(Model)
++   @await Html.GetPreviewBlockGridItemAreasHtmlAsync(Model)
 </section>
 ```
 

--- a/src/Umbraco.Community.BlockPreview.UI/src/blockEditor/block-preview-base.element.ts
+++ b/src/Umbraco.Community.BlockPreview.UI/src/blockEditor/block-preview-base.element.ts
@@ -22,6 +22,14 @@ export abstract class BlockPreviewBaseElement<TContext extends BlockContext = Bl
     protected _blockPreviewContext?: BlockPreviewContext;
     protected _workspaceContextResolved: boolean = false;
 
+    /**
+     * The content type that *owns* the block-editor property this preview belongs
+     * to, when the preview is nested inside another block. Empty for top-level
+     * previews. When set, it takes precedence over the document content type as
+     * `documentTypeUnique`. See {@link observeOwnerContentType}.
+     */
+    protected _ownerContentTypeUnique: string = '';
+
     @property({ attribute: false, hasChanged: (val: any, old: any) => JSON.stringify(val) !== JSON.stringify(old) })
     content?: UmbBlockDataType;
 
@@ -80,6 +88,7 @@ export abstract class BlockPreviewBaseElement<TContext extends BlockContext = Bl
         super();
         this.consumeContext(BLOCK_PREVIEW_CONTEXT, async (context) => {
             this._blockPreviewContext = context;
+            this.observeOwnerContentType();
             await this.setupContextObservers();
         });
     }
@@ -127,7 +136,12 @@ export abstract class BlockPreviewBaseElement<TContext extends BlockContext = Bl
         this._blockContext.unique = unique?.toString() ?? '';
         this._blockPreviewContext?.setUnique(this._blockContext.unique);
 
-        this._blockContext.documentTypeUnique = documentTypeUnique;
+        // `documentTypeUnique` here is the *document's* content type, because the
+        // workspace lookup deliberately reaches past the nearest block workspace to
+        // the document (needed for the node key — see #297/#298). When this preview
+        // is nested, the owning content type is the parent element type instead, so
+        // prefer the owner resolved by observeOwnerContentType() when available.
+        this._blockContext.documentTypeUnique = this._ownerContentTypeUnique || documentTypeUnique;
         this._blockPreviewContext?.setDocumentTypeUnique(this._blockContext.documentTypeUnique);
         this._workspaceContextResolved = true;
 
@@ -163,6 +177,49 @@ export abstract class BlockPreviewBaseElement<TContext extends BlockContext = Bl
                     await this.fetchAndLoadStylesheets();
                 });
             }
+        });
+    }
+
+    /**
+     * Resolves the content type that *owns* the block-editor property, i.e. the one
+     * the server must look the property up on (`documentTypeUnique`).
+     *
+     * When a preview is nested inside another block, the block-editor property it
+     * belongs to is defined on the parent *element type*, not on the document.
+     * handleWorkspaceData() reaches past the nearest block workspace to the document
+     * workspace to resolve the node key (see #297/#298), so on its own it reports the
+     * *document's* content type — and the server then fails to find the property,
+     * returning "The property type is invalid." for every nested block.
+     *
+     * The nearest block workspace, when present, exposes exactly the owning element
+     * type. Observe it and treat its content type as the authoritative
+     * `documentTypeUnique`. Top-level previews have no block workspace, so this never
+     * fires and the document content type from handleWorkspaceData() stands.
+     */
+    protected observeOwnerContentType() {
+        this.consumeContext(UMB_BLOCK_WORKSPACE_CONTEXT, (context) => {
+            if (!context) {
+                return;
+            }
+
+            this.observe(context.content.structure.contentTypeUniques, (contentTypeUniques) => {
+                const owner = contentTypeUniques?.[0];
+                if (!owner || owner === this._ownerContentTypeUnique) {
+                    return;
+                }
+
+                this._ownerContentTypeUnique = owner;
+                this._blockContext.documentTypeUnique = owner;
+
+                // If the preview already resolved (and possibly rendered) using the
+                // document's content type, re-fetch stylesheets and re-render now that
+                // the owning element type is known.
+                if (this._workspaceContextResolved) {
+                    this._stylesheetsAdopted = false;
+                    void this.fetchAndLoadStylesheets();
+                    void this.renderBlockPreview();
+                }
+            });
         });
     }
 

--- a/src/Umbraco.Community.BlockPreview.UI/src/blockEditor/nested-documenttype-resolution.test.ts
+++ b/src/Umbraco.Community.BlockPreview.UI/src/blockEditor/nested-documenttype-resolution.test.ts
@@ -1,0 +1,161 @@
+import { expect, fixture, defineCE } from '@open-wc/testing';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { UmbStringState, UmbArrayState } from '@umbraco-cms/backoffice/observable-api';
+import { UMB_CONTENT_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/content';
+import { UMB_BLOCK_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/block';
+import { BLOCK_PREVIEW_CONTEXT } from '../context/block-preview.context-token';
+import { BlockPreviewBaseElement } from './block-preview-base.element';
+import { BlockListPreviewCustomView } from './block-list-preview.custom-view.element';
+import { BlockSinglePreviewCustomView } from './block-single-preview.custom-view.element';
+import { BlockGridPreviewCustomView } from './block-grid-preview.custom-view.element';
+
+/**
+ * Regression test — follow-up to #298 ("resolve nodeKey for previews nested in
+ * block lists").
+ *
+ * #298 made nested previews reach past the nearest block workspace to the document
+ * workspace so they resolve the document *nodeKey*. But that same lookup also
+ * supplies `documentTypeUnique`, so a nested preview ended up reporting the
+ * *document's* content type. The server looks the block-editor property up on that
+ * content type, and for a nested block the property lives on the parent *element
+ * type*, not the document — so it isn't found and every nested block renders
+ * "The property type is invalid." instead of a preview.
+ *
+ * The fix observes the nearest block workspace and, when present (nested), uses its
+ * content type as the authoritative `documentTypeUnique`. This test provides a
+ * document workspace and a nested block workspace whose content types DIFFER, and
+ * asserts the preview resolves the *block workspace's* content type.
+ *
+ * The list/single/grid views all funnel through the base class, so the test runs
+ * against each.
+ */
+const DOC_KEY = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const DOC_TYPE_KEY = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+// The parent element type that owns the nested block-editor property — distinct
+// from the document's content type.
+const ELEMENT_TYPE_KEY = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+
+class TestHostElement extends UmbLitElement {}
+const testHostTag = defineCE(TestHostElement);
+
+function createHost(parent?: HTMLElement): TestHostElement {
+    const el = document.createElement(testHostTag) as TestHostElement;
+    (parent ?? document.body).appendChild(el);
+    return el;
+}
+
+/** Document content workspace: exposes the document key + the document content type. */
+function createContentWorkspaceFake(host: HTMLElement) {
+    return {
+        IS_CONTENT_WORKSPACE_CONTEXT: true,
+        getEntityType: () => 'document',
+        unique: new UmbStringState(DOC_KEY).asObservable(),
+        structure: {
+            contentTypeUniques: new UmbArrayState<string>([DOC_TYPE_KEY], (x) => x).asObservable(),
+        },
+        getHostElement: () => host,
+    };
+}
+
+/**
+ * Nested block workspace: shadows the document workspace under the shared
+ * 'UmbWorkspaceContext' alias and exposes the *owning element type* — which the
+ * preview must use as documentTypeUnique.
+ */
+function createBlockWorkspaceFake(host: HTMLElement) {
+    return {
+        IS_BLOCK_WORKSPACE_CONTEXT: true,
+        content: {
+            structure: {
+                contentTypeUniques: new UmbArrayState<string>([ELEMENT_TYPE_KEY], (x) => x).asObservable(),
+            },
+        },
+        getHostElement: () => host,
+    };
+}
+
+/** A BlockPreviewContext stand-in that records the documentTypeUnique it is told. */
+function createBlockPreviewContextFake(host: HTMLElement) {
+    const setDocumentTypeUniqueCalls: string[] = [];
+    let stored = '';
+    return {
+        setDocumentTypeUniqueCalls,
+        getUnique: () => DOC_KEY,
+        setUnique: (_u: string) => {},
+        getDocumentTypeUnique: () => stored,
+        setDocumentTypeUnique: (d: string) => { stored = d; setDocumentTypeUniqueCalls.push(d); },
+        requestQueue: { enqueue: <T>(fn: () => Promise<T>) => fn() },
+        getOrCreateStylesheet: (_href: string) => Promise.resolve(new CSSStyleSheet()),
+        getHostElement: () => host,
+    };
+}
+
+async function waitForCondition(fn: () => boolean, timeout = 2000, interval = 20): Promise<boolean> {
+    const start = performance.now();
+    while (performance.now() - start < timeout) {
+        if (fn()) return true;
+        await new Promise((r) => setTimeout(r, interval));
+    }
+    return fn();
+}
+
+interface ViewScenario {
+    name: string;
+    previewTag: string;
+}
+
+const scenarios: ViewScenario[] = [
+    { name: 'block list', previewTag: defineCE(class extends BlockListPreviewCustomView {}) },
+    { name: 'block single', previewTag: defineCE(class extends BlockSinglePreviewCustomView {}) },
+    { name: 'block grid', previewTag: defineCE(class extends BlockGridPreviewCustomView {}) },
+];
+
+scenarios.forEach(({ name, previewTag }) => {
+    describe(`${name} preview documentTypeUnique resolution (follow-up to #298)`, () => {
+        let root: TestHostElement;
+
+        afterEach(() => {
+            root?.remove();
+        });
+
+        it('uses the parent element type as documentTypeUnique when nested', async () => {
+            // root provides the BlockPreview context and the document workspace
+            root = await fixture<TestHostElement>(`<${testHostTag}></${testHostTag}>`);
+            root.provideContext(BLOCK_PREVIEW_CONTEXT, createBlockPreviewContextFake(root) as never);
+            root.provideContext(UMB_CONTENT_WORKSPACE_CONTEXT, createContentWorkspaceFake(root) as never);
+
+            // a block workspace sits between the document and the preview (nested case)
+            const blockHost = createHost(root);
+            await blockHost.updateComplete;
+            blockHost.provideContext(UMB_BLOCK_WORKSPACE_CONTEXT, createBlockWorkspaceFake(blockHost) as never);
+
+            const el = document.createElement(previewTag) as BlockPreviewBaseElement;
+            blockHost.appendChild(el);
+            await el.updateComplete;
+
+            const resolved = await waitForCondition(
+                () => (el as unknown as { _blockContext: { documentTypeUnique: string } })._blockContext.documentTypeUnique === ELEMENT_TYPE_KEY
+            );
+
+            const actual = (el as unknown as { _blockContext: { documentTypeUnique: string } })._blockContext.documentTypeUnique;
+            expect(resolved, `expected nested preview to use the parent element type (${ELEMENT_TYPE_KEY}) ` +
+                `as documentTypeUnique, but got '${actual}' (the document content type is ${DOC_TYPE_KEY})`).to.be.true;
+        });
+
+        it('uses the document content type as documentTypeUnique when not nested', async () => {
+            root = await fixture<TestHostElement>(`<${testHostTag}></${testHostTag}>`);
+            root.provideContext(BLOCK_PREVIEW_CONTEXT, createBlockPreviewContextFake(root) as never);
+            root.provideContext(UMB_CONTENT_WORKSPACE_CONTEXT, createContentWorkspaceFake(root) as never);
+
+            const el = document.createElement(previewTag) as BlockPreviewBaseElement;
+            root.appendChild(el);
+            await el.updateComplete;
+
+            const resolved = await waitForCondition(
+                () => (el as unknown as { _blockContext: { documentTypeUnique: string } })._blockContext.documentTypeUnique === DOC_TYPE_KEY
+            );
+
+            expect(resolved).to.be.true;
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Follow-up to #298. Previews **nested inside another block** render `The property type is invalid.` for every entry instead of a preview. This fixes the `documentTypeUnique` resolution so nested previews work.

## Root cause

#298 made nested previews reach past the nearest block workspace to the **document** workspace so they resolve the document **nodeKey**. But the same lookup (`handleWorkspaceData`) also supplies **`documentTypeUnique`**, so a nested preview ends up reporting the *document's* content type.

Server-side, `BlockPreviewService` looks the block-editor property up on that content type to find its data type and block configuration:

```csharp
IContentType? documentType = await _blockTypeCacheService.GetContentType(documentTypeUnique);
IPropertyType? property = documentType.PropertyTypes.FirstOrDefault(x => x.Alias.Equals(blockEditorAlias));
if (property == null) {
    property = documentType.CompositionPropertyTypes.FirstOrDefault(x => x.Alias.Equals(blockEditorAlias));
    if (property == null)
        return ... InvalidPropertyType;   // "The property type is invalid."
}
```

For a **nested** block, the block-editor property is defined on the parent **element type**, not on the document — so `blockEditorAlias` (correctly resolved from the nested block's manager context) isn't found on the document content type, and every nested block returns `InvalidPropertyType`.

Top-level previews work because there the block-editor property genuinely lives on the document type (directly or via composition).

## Fix

Add `observeOwnerContentType()` to the shared `BlockPreviewBaseElement`. It observes the nearest `UMB_BLOCK_WORKSPACE_CONTEXT` and, when present (i.e. the preview is nested), uses that workspace's content type as the authoritative `documentTypeUnique`. `handleWorkspaceData()` now prefers this owner type; if it resolves after an initial render, the preview re-fetches stylesheets and re-renders.

- **nodeKey** resolution (from the document workspace, per #298) is unchanged.
- **Top-level** previews have no block workspace, so `observeOwnerContentType()` never fires and the document content type continues to be used — no behaviour change.
- All four custom views (grid, list, single, rich text) funnel through the base class, so a single change covers them all.

## Tests

Adds `nested-documenttype-resolution.test.ts`: it provides a document workspace and a nested block workspace whose content types **differ**, and asserts the preview resolves the block workspace's (element) type as `documentTypeUnique` — for the list, single, and grid views.

- **Without** the fix: the three nested cases fail (they report the document content type). 
- **With** the fix: full suite passes (14/14, including the existing #298 nodeKey tests).

## Screenshots

Reproduced on a real Umbraco 18 site — a Cards block whose nested "Cards" is a Block Grid on the block's element type.

**Before** (nested entries error out):

<!-- drag before screenshot here -->

**After** (nested entries render):

<!-- drag after screenshot here -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)