### PR TITLE
refactor: centralize nested owner content-type resolution in base preview element

### DIFF
--- a/src/Umbraco.Community.BlockPreview.UI/src/blockEditor/block-grid-preview.custom-view.element.ts
+++ b/src/Umbraco.Community.BlockPreview.UI/src/blockEditor/block-grid-preview.custom-view.element.ts
@@ -56,7 +56,6 @@ export class BlockGridPreviewCustomView extends BlockPreviewBaseElement<BlockGri
 
     protected async setupContextObservers() {
         this.observePropertyDataset();
-        this.observeOwnerContentType();
         await this.#observeContentWorkspace();
     }
 

--- a/src/Umbraco.Community.BlockPreview.UI/src/blockEditor/block-preview-base.element.ts
+++ b/src/Umbraco.Community.BlockPreview.UI/src/blockEditor/block-preview-base.element.ts
@@ -113,6 +113,10 @@ export abstract class BlockPreviewBaseElement<TContext extends BlockContext = Bl
         super();
         this.consumeContext(BLOCK_PREVIEW_CONTEXT, async (context) => {
             this._blockPreviewContext = context;
+            // Shared across all block types: resolve the owning content type from the
+            // nearest block workspace when nested, so no individual view can silently
+            // miss it. Harmless for top-level previews (no block workspace to observe).
+            this.observeOwnerContentType();
             await this.setupContextObservers();
         });
     }


### PR DESCRIPTION
## Summary

Moves `observeOwnerContentType()` from the Block Grid view's `setupContextObservers()` into the shared `BlockPreviewBaseElement` constructor, so **every** preview view (grid, list, single, rich text) resolves the nested owner content type from one place. Drops the now-redundant call from the grid view.

This is a **consistency/hardening refactor, not a bug fix** — the nested-Grid "The property type is invalid." bug (#293/#291) is already fixed on `v5/dev`. The refactor removes the footgun that caused it: `observeOwnerContentType()` was wired into a single view, so any other view that needs it (or a new view) would silently miss it.

## Why

Server-side, only `RenderGridBlock` looks the block-editor property up on `documentTypeUnique`, so only Grid can return "The property type is invalid." when nested. That's why the fix was Grid-only. But wiring the resolver per-view is fragile — centralizing it in the base means coverage can't regress by omission.

## Change

- **`block-preview-base.element.ts`** — call `observeOwnerContentType()` from the base constructor's `BLOCK_PREVIEW_CONTEXT` callback.
- **`block-grid-preview.custom-view.element.ts`** — remove the explicit call.

The `observeOwnerContentType()` method body is unchanged (keeps `setDocumentTypeUnique` propagation and the late-arriving-workspace re-render). It's a no-op for top-level previews (no block workspace) and for views that don't use `documentTypeUnique` server-side.

## Tests

Full `web-test-runner` suite passes (16/16), including the existing Grid owner-content-type resolution test — confirming Grid still resolves the owner type now that it comes from the base.

> Note: the comment in `nested-owner-contenttype-resolution.test.ts` still describes the resolution as "Block Grid only"; that's now slightly stale (the wiring is shared) but the test itself remains Grid-scoped. Left untouched to keep this diff to the two source files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)