### PR TITLE
refactor: Deduplicate the block preview rendering pipeline

### DIFF
--- a/docs/advanced-customization.md
+++ b/docs/advanced-customization.md
@@ -463,13 +463,16 @@ public class CustomPreviewContentResolver : IPreviewContentResolver
 {
     private readonly IUmbracoContextAccessor _umbracoContextAccessor;
     private readonly ILanguageService _languageService;
+    private readonly ContextCultureService _contextCultureService;
 
     public CustomPreviewContentResolver(
         IUmbracoContextAccessor umbracoContextAccessor,
-        ILanguageService languageService)
+        ILanguageService languageService,
+        ContextCultureService contextCultureService)
     {
         _umbracoContextAccessor = umbracoContextAccessor;
         _languageService = languageService;
+        _contextCultureService = contextCultureService;
     }
 
     public IPublishedContent? Resolve(Guid? nodeKey, Guid? documentTypeUnique, out bool isActualContent)
@@ -494,10 +497,13 @@ public class CustomPreviewContentResolver : IPreviewContentResolver
     public async Task<string?> ResolveCultureAsync(string? requestedCulture, IPublishedContent? content)
     {
         // e.g. always prefer the requested culture and skip the domain-culture fallback
-        if (!string.IsNullOrWhiteSpace(requestedCulture) && requestedCulture != "undefined")
-            return requestedCulture;
+        var currentCulture = !string.IsNullOrWhiteSpace(requestedCulture) && requestedCulture != "undefined"
+            ? requestedCulture
+            : await _languageService.GetDefaultIsoCodeAsync();
 
-        return await _languageService.GetDefaultIsoCodeAsync();
+        // Calling SetCulture is required: the return value alone does not apply the culture to Umbraco's context.
+        _contextCultureService.SetCulture(currentCulture);
+        return currentCulture;
     }
 
     public Task SetupPublishedRequestAsync(IPublishedContent? content, Uri requestUrl)
@@ -515,7 +521,9 @@ Runs the shared preview request pipeline used by all four preview endpoints (`pr
 
 ```cs
 using System.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Community.BlockPreview.Interfaces;
 using Umbraco.Community.BlockPreview.Services;
 

--- a/docs/advanced-customization.md
+++ b/docs/advanced-customization.md
@@ -267,13 +267,16 @@ builder.Services.AddUnique<IBlockPreviewResponseEnricher, BlockPreviewResponseEn
 
 ## Replaceable Services
 
-BlockPreview's internal rendering pipeline is split into three focused services that can each be replaced independently. All three are registered as scoped services (per-request), so you can safely inject other scoped services like `IPublishedContentQuery` or access `HttpContext`.
+BlockPreview's internal rendering pipeline is split into six focused services that can each be replaced independently. All six are registered as scoped services (per-request), so you can safely inject other scoped services like `IPublishedContentQuery` or access `HttpContext`.
 
 | Interface | Default | Responsibility | Lifecycle |
 |-----------|---------|----------------|-----------|
 | `IBlockModelFactory` | `BlockModelFactory` | Creates typed content/settings models and block item instances (BlockGridItem, BlockListItem, etc.) | Scoped |
 | `IBlockViewRenderer` | `BlockViewRenderer` | Renders block previews using either ViewComponents or partial views | Scoped |
 | `IBlockDataConverter` | `BlockDataConverter` | Deserializes raw block JSON and converts block item data to published elements | Scoped |
+| `IPreviewContentResolver` | `PreviewContentResolver` | Resolves the published content, culture, and published request for a block preview | Scoped |
+| `IPreviewRequestExecutor` | `PreviewRequestExecutor` | Runs the shared preview request pipeline used by all four preview endpoints: verifies generated models exist, resolves content/culture, enriches the request, invokes the block-type-specific renderer, enriches the response, and formats errors | Scoped |
+| `IMarkupSanitizer` | `MarkupSanitizer` | Sanitizes rendered block preview markup before it is sent to the backoffice (rewrites anchor hrefs to no-ops, disables form controls) | Scoped |
 
 ### IBlockModelFactory
 
@@ -446,6 +449,124 @@ public class CustomBlockDataConverter : IBlockDataConverter
 }
 ```
 
+### IPreviewContentResolver
+
+Resolves the published content, culture, and published request that a block preview renders against. Override this to change how content is located (e.g. a different placeholder strategy for unsaved nodes) or how culture is chosen.
+
+```cs
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Web;
+using Umbraco.Community.BlockPreview.Interfaces;
+
+public class CustomPreviewContentResolver : IPreviewContentResolver
+{
+    private readonly IUmbracoContextAccessor _umbracoContextAccessor;
+    private readonly ILanguageService _languageService;
+
+    public CustomPreviewContentResolver(
+        IUmbracoContextAccessor umbracoContextAccessor,
+        ILanguageService languageService)
+    {
+        _umbracoContextAccessor = umbracoContextAccessor;
+        _languageService = languageService;
+    }
+
+    public IPublishedContent? Resolve(Guid? nodeKey, Guid? documentTypeUnique, out bool isActualContent)
+    {
+        isActualContent = false;
+
+        if (!_umbracoContextAccessor.TryGetUmbracoContext(out var context))
+            return null;
+
+        // Try an actual node first, then fall back to your own placeholder-resolution
+        // strategy instead of the default type-cache scan.
+        var content = nodeKey.HasValue ? context.Content?.GetById(preview: true, nodeKey.Value) : null;
+        if (content != null)
+        {
+            isActualContent = true;
+            return content;
+        }
+
+        return /* your placeholder-resolution logic */;
+    }
+
+    public async Task<string?> ResolveCultureAsync(string? requestedCulture, IPublishedContent? content)
+    {
+        // e.g. always prefer the requested culture and skip the domain-culture fallback
+        if (!string.IsNullOrWhiteSpace(requestedCulture) && requestedCulture != "undefined")
+            return requestedCulture;
+
+        return await _languageService.GetDefaultIsoCodeAsync();
+    }
+
+    public Task SetupPublishedRequestAsync(IPublishedContent? content, Uri requestUrl)
+    {
+        // Build and assign your own PublishedRequest, or leave this a no-op if your
+        // custom views don't rely on the ambient PublishedRequest.
+        return Task.CompletedTask;
+    }
+}
+```
+
+### IPreviewRequestExecutor
+
+Runs the shared preview request pipeline used by all four preview endpoints (`preview/grid`, `preview/list`, `preview/single`, `preview/rte`): it verifies generated models exist, resolves content and culture via `IPreviewContentResolver`, enriches the request, invokes the block-type-specific renderer passed in by the controller, enriches the response, and falls back to an error template on failure. Because it wraps so much behaviour, the most practical way to customise it is to decorate the default implementation rather than reimplement it from scratch — for example, to add timing or telemetry around every preview render.
+
+```cs
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Umbraco.Community.BlockPreview.Interfaces;
+using Umbraco.Community.BlockPreview.Services;
+
+public class CustomPreviewRequestExecutor : IPreviewRequestExecutor
+{
+    private readonly PreviewRequestExecutor _inner;
+    private readonly ILogger<CustomPreviewRequestExecutor> _logger;
+
+    public CustomPreviewRequestExecutor(PreviewRequestExecutor inner, ILogger<CustomPreviewRequestExecutor> logger)
+    {
+        _inner = inner;
+        _logger = logger;
+    }
+
+    public async Task<string> ExecuteAsync(
+        PreviewRenderRequest request,
+        Func<string, IPublishedContent, ControllerContext, string, Guid, string, string?, int?, Task<string>> render)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        var markup = await _inner.ExecuteAsync(request, render);
+        _logger.LogInformation("Rendered preview for {Alias} in {ElapsedMs}ms", request.ContentElementAlias, stopwatch.ElapsedMilliseconds);
+        return markup;
+    }
+}
+```
+
+Because the decorator needs access to the default implementation, register the concrete `PreviewRequestExecutor` class alongside your decorator:
+
+```cs
+builder.Services.AddScoped<PreviewRequestExecutor>();
+builder.Services.AddScoped<IPreviewRequestExecutor, CustomPreviewRequestExecutor>();
+```
+
+### IMarkupSanitizer
+
+Sanitizes rendered block preview markup before it is sent to the backoffice. The default implementation rewrites anchor `href` attributes to no-ops and disables form controls, so the preview can't navigate away from or submit data within the backoffice. Override this to add your own rules, e.g. stripping `<script>` tags entirely.
+
+```cs
+using Umbraco.Community.BlockPreview.Interfaces;
+
+public class CustomMarkupSanitizer : IMarkupSanitizer
+{
+    public string CleanUp(string markup)
+    {
+        // Disable scripts in addition to the default anchor/form-control sanitization.
+        return markup.Replace("<script", "<!--script", StringComparison.OrdinalIgnoreCase)
+                      .Replace("</script>", "</script-->", StringComparison.OrdinalIgnoreCase);
+    }
+}
+```
+
 ### Registering Custom Services
 
 Replace any service in `Program.cs` after calling `AddBlockPreview`:
@@ -463,4 +584,11 @@ builder.CreateUmbracoBuilder()
 builder.Services.AddScoped<IBlockModelFactory, CustomBlockModelFactory>();
 builder.Services.AddScoped<IBlockViewRenderer, CustomBlockViewRenderer>();
 builder.Services.AddScoped<IBlockDataConverter, CustomBlockDataConverter>();
+builder.Services.AddScoped<IPreviewContentResolver, CustomPreviewContentResolver>();
+builder.Services.AddScoped<IMarkupSanitizer, CustomMarkupSanitizer>();
+
+// IPreviewRequestExecutor's default implementation is decorated rather than replaced outright
+// (see the IPreviewRequestExecutor section above), so both registrations are needed:
+builder.Services.AddScoped<PreviewRequestExecutor>();
+builder.Services.AddScoped<IPreviewRequestExecutor, CustomPreviewRequestExecutor>();
 ```

--- a/src/Umbraco.Community.BlockPreview/BlockPreviewComposer.cs
+++ b/src/Umbraco.Community.BlockPreview/BlockPreviewComposer.cs
@@ -48,6 +48,7 @@ namespace Umbraco.Community.BlockPreview
                 ActivatorUtilities.CreateInstance<BlockPreviewService>(sp));
             builder.Services.AddScoped<IBlockPreviewRequestEnricher, NoopBlockPreviewRequestEnricher>();
             builder.Services.AddScoped<IBlockPreviewResponseEnricher, NoopBlockPreviewResponseEnricher>();
+            builder.Services.AddScoped<IMarkupSanitizer, MarkupSanitizer>();
 
             builder.Services.AddScoped<ContextCultureService>();
 

--- a/src/Umbraco.Community.BlockPreview/BlockPreviewComposer.cs
+++ b/src/Umbraco.Community.BlockPreview/BlockPreviewComposer.cs
@@ -49,6 +49,7 @@ namespace Umbraco.Community.BlockPreview
             builder.Services.AddScoped<IBlockPreviewRequestEnricher, NoopBlockPreviewRequestEnricher>();
             builder.Services.AddScoped<IBlockPreviewResponseEnricher, NoopBlockPreviewResponseEnricher>();
             builder.Services.AddScoped<IMarkupSanitizer, MarkupSanitizer>();
+            builder.Services.AddScoped<IPreviewContentResolver, PreviewContentResolver>();
 
             builder.Services.AddScoped<ContextCultureService>();
 

--- a/src/Umbraco.Community.BlockPreview/BlockPreviewComposer.cs
+++ b/src/Umbraco.Community.BlockPreview/BlockPreviewComposer.cs
@@ -50,6 +50,7 @@ namespace Umbraco.Community.BlockPreview
             builder.Services.AddScoped<IBlockPreviewResponseEnricher, NoopBlockPreviewResponseEnricher>();
             builder.Services.AddScoped<IMarkupSanitizer, MarkupSanitizer>();
             builder.Services.AddScoped<IPreviewContentResolver, PreviewContentResolver>();
+            builder.Services.AddScoped<IPreviewRequestExecutor, PreviewRequestExecutor>();
 
             builder.Services.AddScoped<ContextCultureService>();
 

--- a/src/Umbraco.Community.BlockPreview/CompatibilitySuppressions.xml
+++ b/src/Umbraco.Community.BlockPreview/CompatibilitySuppressions.xml
@@ -10,6 +10,13 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Umbraco.Community.BlockPreview.Controllers.BlockPreviewApiController.#ctor(Umbraco.Cms.Core.Routing.IPublishedRouter,Microsoft.Extensions.Logging.ILogger{Umbraco.Community.BlockPreview.Controllers.BlockPreviewApiController},Umbraco.Cms.Core.Web.IUmbracoContextAccessor,Umbraco.Community.BlockPreview.Services.ContextCultureService,Umbraco.Community.BlockPreview.Interfaces.IBlockPreviewService,Umbraco.Cms.Core.Services.ILanguageService,Microsoft.Extensions.Options.IOptions{Umbraco.Community.BlockPreview.BlockPreviewOptions},Umbraco.Cms.Core.Composing.ITypeFinder,Umbraco.Cms.Core.Cache.AppCaches,Umbraco.Cms.Infrastructure.HybridCache.IElementsCache,Umbraco.Cms.Core.PublishedCache.IDocumentCacheService,Umbraco.Cms.Core.PublishedCache.IPublishedContentTypeCache,Umbraco.Cms.Infrastructure.Scoping.IScopeProvider,Umbraco.Community.BlockPreview.Interfaces.IBlockPreviewRequestEnricher)</Target>
+    <Left>lib/net10.0/Umbraco.Community.BlockPreview.dll</Left>
+    <Right>lib/net10.0/Umbraco.Community.BlockPreview.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Umbraco.Community.BlockPreview.Extensions.BlockPreviewUmbracoBuilderExtensions.AddInternal(Umbraco.Cms.Core.DependencyInjection.IUmbracoBuilder,System.Action{Microsoft.Extensions.Options.OptionsBuilder{Umbraco.Community.BlockPreview.BlockPreviewOptions}})</Target>
     <Left>lib/net10.0/Umbraco.Community.BlockPreview.dll</Left>
     <Right>lib/net10.0/Umbraco.Community.BlockPreview.dll</Right>

--- a/src/Umbraco.Community.BlockPreview/Controllers/BlockPreviewApiController.cs
+++ b/src/Umbraco.Community.BlockPreview/Controllers/BlockPreviewApiController.cs
@@ -1,22 +1,13 @@
 ﻿using Asp.Versioning;
-using HtmlAgilityPack;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Composing;
-using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Models.PublishedContent;
-using Umbraco.Cms.Core.PublishedCache;
-using Umbraco.Cms.Core.Routing;
 using Umbraco.Cms.Core.Services;
-using Umbraco.Cms.Core.Web;
-using Umbraco.Cms.Infrastructure.HybridCache;
-using Umbraco.Cms.Infrastructure.Scoping;
 using Umbraco.Community.BlockPreview.Enums;
 using Umbraco.Community.BlockPreview.Interfaces;
 using Umbraco.Community.BlockPreview.Services;
@@ -31,20 +22,13 @@ namespace Umbraco.Community.BlockPreview.Controllers
     [ApiExplorerSettings(GroupName = "BlockPreview")]
     public class BlockPreviewApiController : BlockPreviewApiControllerBase
     {
-        private readonly IPublishedRouter _publishedRouter;
-        private readonly ILogger<BlockPreviewApiController> _logger;
-        private readonly IUmbracoContextAccessor _umbracoContextAccessor;
-        private readonly ContextCultureService _contextCultureService;
+        private readonly IPreviewRequestExecutor _requestExecutor;
+        private readonly IMarkupSanitizer _markupSanitizer;
+        private readonly IPreviewContentResolver _contentResolver;
         private readonly IBlockPreviewService _blockPreviewService;
-        private readonly ILanguageService _languageService;
         private readonly IOptions<BlockPreviewOptions> _blockPreviewSettings;
         private readonly IAppPolicyCache _runtimeCache;
-        private readonly ITypeFinder _typeFinder;
-        private readonly IDocumentCacheService _documentCacheService;
-        private readonly IPublishedContentTypeCache _contentTypeCache;
-        private readonly IScopeProvider _scopeProvider;
         private readonly IBlockPreviewRequestEnricher _requestEnricher;
-        private readonly IBlockPreviewResponseEnricher _responseEnricher;
 
         private static readonly TimeSpan CacheDuration = TimeSpan.FromHours(1);
 
@@ -53,94 +37,29 @@ namespace Umbraco.Community.BlockPreview.Controllers
         /// </summary>
         [ActivatorUtilitiesConstructor]
         public BlockPreviewApiController(
-            IPublishedRouter publishedRouter,
-            ILogger<BlockPreviewApiController> logger,
-            IUmbracoContextAccessor umbracoContextAccessor,
-            ContextCultureService contextCultureSwitcher,
+            IPreviewRequestExecutor requestExecutor,
+            IMarkupSanitizer markupSanitizer,
+            IPreviewContentResolver contentResolver,
             IBlockPreviewService blockPreviewService,
-            ILanguageService languageService,
             IOptions<BlockPreviewOptions> blockPreviewSettings,
-            ITypeFinder typeFinder,
             AppCaches appCaches,
-            IElementsCache elementsCache,
-            IDocumentCacheService documentCacheService,
-            IPublishedContentTypeCache contentTypeCache,
-            IScopeProvider scopeProvider,
-            IBlockPreviewRequestEnricher requestEnricher,
-            IBlockPreviewResponseEnricher responseEnricher)
-        {
-            _publishedRouter = publishedRouter;
-            _logger = logger;
-            _umbracoContextAccessor = umbracoContextAccessor;
-            _contextCultureService = contextCultureSwitcher;
-            _blockPreviewService = blockPreviewService;
-            _languageService = languageService;
-            _blockPreviewSettings = blockPreviewSettings;
-            _typeFinder = typeFinder;
-            _runtimeCache = appCaches.RuntimeCache;
-            _documentCacheService = documentCacheService;
-            _contentTypeCache = contentTypeCache;
-            _scopeProvider = scopeProvider;
-            _requestEnricher = requestEnricher;
-            _responseEnricher = responseEnricher;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="BlockPreviewApiController"/> class.
-        /// </summary>
-        [Obsolete("Use the constructor with IBlockPreviewResponseEnricher parameter instead.")]
-        public BlockPreviewApiController(
-            IPublishedRouter publishedRouter,
-            ILogger<BlockPreviewApiController> logger,
-            IUmbracoContextAccessor umbracoContextAccessor,
-            ContextCultureService contextCultureSwitcher,
-            IBlockPreviewService blockPreviewService,
-            ILanguageService languageService,
-            IOptions<BlockPreviewOptions> blockPreviewSettings,
-            ITypeFinder typeFinder,
-            AppCaches appCaches,
-            IElementsCache elementsCache,
-            IDocumentCacheService documentCacheService,
-            IPublishedContentTypeCache contentTypeCache,
-            IScopeProvider scopeProvider,
             IBlockPreviewRequestEnricher requestEnricher)
-            : this(
-                publishedRouter,
-                logger,
-                umbracoContextAccessor,
-                contextCultureSwitcher,
-                blockPreviewService,
-                languageService,
-                blockPreviewSettings,
-                typeFinder,
-                appCaches,
-                elementsCache,
-                documentCacheService,
-                contentTypeCache,
-                scopeProvider,
-                requestEnricher,
-                StaticServiceProvider.Instance.GetRequiredService<IBlockPreviewResponseEnricher>())
         {
+            _requestExecutor = requestExecutor;
+            _markupSanitizer = markupSanitizer;
+            _contentResolver = contentResolver;
+            _blockPreviewService = blockPreviewService;
+            _blockPreviewSettings = blockPreviewSettings;
+            _runtimeCache = appCaches.RuntimeCache;
+            _requestEnricher = requestEnricher;
         }
 
         #region Public
-        /// <summary>
-        /// Renders a preview for a grid block using the associated Razor view or ViewComponent.
-        /// </summary>
-        /// <param name="blockData">The JSON content data of the block.</param>
-        /// <param name="nodeKey">The <see cref="Guid"/> that represents the Umbraco node.</param>
-        /// <param name="blockEditorAlias">The alias of the block editor</param>
-        /// <param name="contentElementAlias">The alias of the content being rendered</param>
-        /// <param name="culture">The current culture</param>
-        /// <param name="documentTypeUnique">The <see cref="Guid"/> that represents the Umbraco node</param>
-        /// <param name="contentUdi">The <see cref="Cms.Core.Udi"/> that represents the content element</param>
-        /// <param name="settingsUdi">The <see cref="Cms.Core.Udi"/> that represents the settings element</param>
-        /// <param name="blockIndex">The <see cref="int"/> that represents the block index</param>
-        /// <returns>The markup to render in the preview.</returns>
+
         [HttpPost("preview/grid")]
         [MapToApiVersion("1.0")]
         [ProducesResponseType(typeof(string), 200)]
-        public async Task<IActionResult> PreviewGridBlock(
+        public Task<IActionResult> PreviewGridBlock(
             [FromBody] string blockData,
             [FromQuery] Guid nodeKey = default,
             [FromQuery] string blockEditorAlias = "",
@@ -150,58 +69,13 @@ namespace Umbraco.Community.BlockPreview.Controllers
             [FromQuery] string contentUdi = "",
             [FromQuery] string? settingsUdi = default,
             [FromQuery] int? blockIndex = 0)
-        {
-            string markup;
+            => RunPreviewAsync(blockData, nodeKey, blockEditorAlias, contentElementAlias, culture,
+                documentTypeUnique, contentUdi, settingsUdi, blockIndex, _blockPreviewService.RenderGridBlock);
 
-            if (CheckGeneratedModelsExist())
-            {
-                try
-                {
-                    IPublishedContent? content = GetPublishedContent(nodeKey, documentTypeUnique, out bool isActualContent);
-
-                    string? currentCulture = await GetCurrentCulture(culture, content);
-
-                    await SetupPublishedRequest(currentCulture, isActualContent ? content : null);
-
-                    await _requestEnricher.EnrichAsync(HttpContext, content, blockEditorAlias, contentElementAlias, contentUdi, settingsUdi, blockIndex);
-
-                    markup = await _blockPreviewService.RenderGridBlock(blockData, content!, ControllerContext, blockEditorAlias, documentTypeUnique, contentUdi, settingsUdi, blockIndex);
-
-                    markup = await _responseEnricher.EnrichAsync(markup, HttpContext, content, blockEditorAlias, contentElementAlias, contentUdi, settingsUdi, blockIndex);
-                }
-                catch (Exception ex)
-                {
-                    markup = string.Format(Constants.ErrorMessages.ErrorTemplate, string.Format(Constants.ErrorMessages.RenderError, ex.Message));
-                    _logger.LogError(ex, string.Format(Constants.ErrorMessages.LoggerError, contentElementAlias));
-                }
-            }
-
-            else
-            {
-                markup = string.Format(Constants.ErrorMessages.WarningTemplate, Constants.ErrorMessages.ModelsBuilderError);
-            }
-
-            string? cleanMarkup = CleanUpMarkup(markup);
-            return Ok(cleanMarkup);
-        }
-
-        /// <summary>
-        /// Renders a preview for a block list block using the associated Razor view or ViewComponent.
-        /// </summary>
-        /// <param name="blockData">The JSON content data of the block.</param>
-        /// <param name="nodeKey">The key of the node.</param>
-        /// <param name="blockEditorAlias">The alias of the block editor</param>
-        /// <param name="contentElementAlias">The alias of the content being rendered</param>
-        /// <param name="culture">The current culture</param>
-        /// <param name="documentTypeUnique">The <see cref="Guid"/> that represents the Umbraco node</param>
-        /// <param name="contentUdi">The <see cref="Cms.Core.Udi"/> that represents the content element</param>
-        /// <param name="settingsUdi">The <see cref="Cms.Core.Udi"/> that represents the settings element</param>
-        /// <param name="blockIndex">The <see cref="int"/> that represents the block index</param>
-        /// <returns>The markup to render in the preview.</returns>
         [HttpPost("preview/list")]
         [MapToApiVersion("1.0")]
         [ProducesResponseType(typeof(string), 200)]
-        public async Task<IActionResult> PreviewListBlock(
+        public Task<IActionResult> PreviewListBlock(
             [FromBody] string blockData,
             [FromQuery] Guid nodeKey = default,
             [FromQuery] string blockEditorAlias = "",
@@ -211,156 +85,60 @@ namespace Umbraco.Community.BlockPreview.Controllers
             [FromQuery] string contentUdi = "",
             [FromQuery] string? settingsUdi = default,
             [FromQuery] int? blockIndex = 0)
-        {
-            string markup;
+            => RunPreviewAsync(blockData, nodeKey, blockEditorAlias, contentElementAlias, culture,
+                documentTypeUnique, contentUdi, settingsUdi, blockIndex, _blockPreviewService.RenderListBlock);
 
-            if (CheckGeneratedModelsExist())
-            {
-                try
-                {
-                    IPublishedContent? content = GetPublishedContent(nodeKey, documentTypeUnique, out bool isActualContent);
+        [HttpPost("preview/single")]
+        [MapToApiVersion("1.0")]
+        [ProducesResponseType(typeof(string), 200)]
+        public Task<IActionResult> PreviewSingleBlock(
+            [FromBody] string blockData,
+            [FromQuery] Guid nodeKey = default,
+            [FromQuery] string blockEditorAlias = "",
+            [FromQuery] string contentElementAlias = "",
+            [FromQuery] string culture = "",
+            [FromQuery] Guid documentTypeUnique = default,
+            [FromQuery] string contentUdi = "",
+            [FromQuery] string? settingsUdi = default,
+            [FromQuery] int? blockIndex = 0)
+            => RunPreviewAsync(blockData, nodeKey, blockEditorAlias, contentElementAlias, culture,
+                documentTypeUnique, contentUdi, settingsUdi, blockIndex, _blockPreviewService.RenderSingleBlock);
 
-                    string? currentCulture = await GetCurrentCulture(culture, content);
-
-                    await SetupPublishedRequest(currentCulture, isActualContent ? content : null);
-
-                    await _requestEnricher.EnrichAsync(HttpContext, content, blockEditorAlias, contentElementAlias, contentUdi, settingsUdi, blockIndex);
-
-                    markup = await _blockPreviewService.RenderListBlock(blockData, content!, ControllerContext, blockEditorAlias, documentTypeUnique, contentUdi, settingsUdi, blockIndex);
-
-                    markup = await _responseEnricher.EnrichAsync(markup, HttpContext, content, blockEditorAlias, contentElementAlias, contentUdi, settingsUdi, blockIndex);
-                }
-                catch (Exception ex)
-                {
-                    markup = string.Format(Constants.ErrorMessages.ErrorTemplate, string.Format(Constants.ErrorMessages.RenderError, ex.Message));
-                    _logger.LogError(ex, string.Format(Constants.ErrorMessages.LoggerError, contentElementAlias));
-                }
-            }
-
-            else
-            {
-                markup = string.Format(Constants.ErrorMessages.WarningTemplate, Constants.ErrorMessages.ModelsBuilderError);
-            }
-
-            string? cleanMarkup = CleanUpMarkup(markup);
-            return Ok(cleanMarkup);
-        }
-
-        /// <summary>
-        /// Renders a preview for a rich text block using the associated Razor view or ViewComponent.
-        /// </summary>
-        /// <param name="blockData">The JSON content data of the block.</param>
-        /// <param name="nodeKey">The key of the node.</param>
-        /// <param name="blockEditorAlias">The alias of the block editor</param>
-        /// <param name="contentElementAlias">The alias of the content being rendered</param>
-        /// <param name="culture">The current culture</param>
-        /// <param name="documentTypeUnique">The <see cref="Guid"/> that represents the Umbraco node</param>
-        /// <returns>The markup to render in the preview.</returns>
         [HttpPost("preview/rte")]
         [MapToApiVersion("1.0")]
         [ProducesResponseType(typeof(string), 200)]
-        public async Task<IActionResult> PreviewRichTextMarkup(
+        public Task<IActionResult> PreviewRichTextMarkup(
             [FromBody] string blockData,
             [FromQuery] Guid nodeKey = default,
             [FromQuery] string blockEditorAlias = "",
             [FromQuery] string contentElementAlias = "",
             [FromQuery] string culture = "",
             [FromQuery] Guid documentTypeUnique = default)
+            => RunPreviewAsync(blockData, nodeKey, blockEditorAlias, contentElementAlias, culture,
+                documentTypeUnique, contentUdi: null, settingsUdi: null, blockIndex: null,
+                (bd, c, cc, _, _, _, _, _) => _blockPreviewService.RenderRichTextBlock(bd, c, cc));
+
+        #endregion
+
+        #region Private
+
+        private async Task<IActionResult> RunPreviewAsync(
+            string blockData, Guid nodeKey, string blockEditorAlias, string contentElementAlias,
+            string? culture, Guid documentTypeUnique, string? contentUdi, string? settingsUdi, int? blockIndex,
+            Func<string, IPublishedContent, ControllerContext, string, Guid, string, string?, int?, Task<string>> render)
         {
-            string markup;
+            var request = new PreviewRenderRequest(
+                blockData, nodeKey, blockEditorAlias, contentElementAlias, culture, documentTypeUnique,
+                contentUdi, settingsUdi, blockIndex, HttpContext, ControllerContext);
 
-            if (CheckGeneratedModelsExist())
-            {
-                try
-                {
-                    IPublishedContent? content = GetPublishedContent(nodeKey, documentTypeUnique, out bool isActualContent);
+            string markup = await _requestExecutor.ExecuteAsync(request, render);
 
-                    string? currentCulture = await GetCurrentCulture(culture, content);
-
-                    await SetupPublishedRequest(currentCulture, isActualContent ? content : null);
-
-                    await _requestEnricher.EnrichAsync(HttpContext, content, blockEditorAlias, contentElementAlias);
-
-                    markup = await _blockPreviewService.RenderRichTextBlock(blockData, content!, ControllerContext);
-
-                    markup = await _responseEnricher.EnrichAsync(markup, HttpContext, content, blockEditorAlias, contentElementAlias);
-                }
-                catch (Exception ex)
-                {
-                    markup = string.Format(Constants.ErrorMessages.ErrorTemplate, string.Format(Constants.ErrorMessages.RenderError, ex.Message));
-                    _logger.LogError(ex, string.Format(Constants.ErrorMessages.LoggerError, contentElementAlias));
-                }
-            }
-
-            else
-            {
-                markup = string.Format(Constants.ErrorMessages.WarningTemplate, Constants.ErrorMessages.ModelsBuilderError);
-            }
-
-            string? cleanMarkup = CleanUpMarkup(markup);
-            return Ok(cleanMarkup);
+            return Ok(_markupSanitizer.CleanUp(markup));
         }
 
-        /// <summary>
-        /// Renders a preview for a single block using the associated Razor view or ViewComponent.
-        /// </summary>
-        /// <param name="blockData">The JSON content data of the block.</param>
-        /// <param name="nodeKey">The key of the node.</param>
-        /// <param name="blockEditorAlias">The alias of the block editor</param>
-        /// <param name="contentElementAlias">The alias of the content being rendered</param>
-        /// <param name="culture">The current culture</param>
-        /// <param name="documentTypeUnique">The <see cref="Guid"/> that represents the Umbraco node</param>
-        /// <param name="contentUdi">The <see cref="Cms.Core.Udi"/> that represents the content element</param>
-        /// <param name="settingsUdi">The <see cref="Cms.Core.Udi"/> that represents the settings element</param>
-        /// <param name="blockIndex">The <see cref="int"/> that represents the block index</param>
-        /// <returns>The markup to render in the preview.</returns>
-        [HttpPost("preview/single")]
-        [MapToApiVersion("1.0")]
-        [ProducesResponseType(typeof(string), 200)]
-        public async Task<IActionResult> PreviewSingleBlock(
-            [FromBody] string blockData,
-            [FromQuery] Guid nodeKey = default,
-            [FromQuery] string blockEditorAlias = "",
-            [FromQuery] string contentElementAlias = "",
-            [FromQuery] string culture = "",
-            [FromQuery] Guid documentTypeUnique = default,
-            [FromQuery] string contentUdi = "",
-            [FromQuery] string? settingsUdi = default,
-            [FromQuery] int? blockIndex = 0)
-        {
-            string markup;
+        #endregion
 
-            if (CheckGeneratedModelsExist())
-            {
-                try
-                {
-                    IPublishedContent? content = GetPublishedContent(nodeKey, documentTypeUnique, out bool isActualContent);
-
-                    string? currentCulture = await GetCurrentCulture(culture, content);
-
-                    await SetupPublishedRequest(currentCulture, isActualContent ? content : null);
-
-                    await _requestEnricher.EnrichAsync(HttpContext, content, blockEditorAlias, contentElementAlias, contentUdi, settingsUdi, blockIndex);
-
-                    markup = await _blockPreviewService.RenderSingleBlock(blockData, content!, ControllerContext, blockEditorAlias, documentTypeUnique, contentUdi, settingsUdi, blockIndex);
-
-                    markup = await _responseEnricher.EnrichAsync(markup, HttpContext, content, blockEditorAlias, contentElementAlias, contentUdi, settingsUdi, blockIndex);
-                }
-                catch (Exception ex)
-                {
-                    markup = string.Format(Constants.ErrorMessages.ErrorTemplate, string.Format(Constants.ErrorMessages.RenderError, ex.Message));
-                    _logger.LogError(ex, string.Format(Constants.ErrorMessages.LoggerError, contentElementAlias));
-                }
-            }
-
-            else
-            {
-                markup = string.Format(Constants.ErrorMessages.WarningTemplate, Constants.ErrorMessages.ModelsBuilderError);
-            }
-
-            string? cleanMarkup = CleanUpMarkup(markup);
-            return Ok(cleanMarkup);
-        }
+        #region Public
 
         /// <summary>
         /// Retrieves the stylesheet paths for a single block preview.
@@ -597,124 +375,10 @@ namespace Umbraco.Community.BlockPreview.Controllers
         #endregion
 
         #region Private
-        private bool CheckGeneratedModelsExist()
-        {
-            return _runtimeCache.GetCacheItem(Constants.CacheKeys.GeneratedModels, () =>
-            {
-                return _typeFinder.FindClassesWithAttribute<PublishedModelAttribute>().Any();
-            }, CacheDuration);
-        }
-
-        private async Task<string?> GetCurrentCulture(string? culture, IPublishedContent? content = null)
-        {
-            var currentCulture = string.IsNullOrWhiteSpace(culture) || culture == "undefined"
-                ? null
-                : culture;
-
-            // Try domain-based culture from the content
-            currentCulture ??= content?.GetCultureFromDomains();
-
-            // If only one language is configured, use it regardless of default flag
-            if (string.IsNullOrEmpty(currentCulture))
-            {
-                var allLanguages = await _languageService.GetAllAsync();
-                var languages = allLanguages.ToList();
-                currentCulture = languages.Count == 1
-                    ? languages[0].IsoCode
-                    : await _languageService.GetDefaultIsoCodeAsync();
-            }
-
-            _contextCultureService.SetCulture(currentCulture);
-
-            return currentCulture;
-        }
-
-        private async Task SetupPublishedRequest(string? culture, IPublishedContent? content = null)
-        {
-            if (!_umbracoContextAccessor.TryGetUmbracoContext(out IUmbracoContext? context))
-                return;
-
-            var requestUrl = new Uri(Request.GetDisplayUrl());
-            var requestBuilder = await _publishedRouter.CreateRequestAsync(requestUrl);
-
-            if (content != null)
-                requestBuilder.SetPublishedContent(content);
-
-            context.PublishedRequest = requestBuilder.Build();
-        }
 
         private IPublishedContent? GetPublishedContent(Guid? nodeKey = default, Guid? documentTypeUnique = default)
-        {
-            return GetPublishedContent(nodeKey, documentTypeUnique, out _);
-        }
+            => _contentResolver.Resolve(nodeKey, documentTypeUnique, out _);
 
-        private IPublishedContent? GetPublishedContent(Guid? nodeKey, Guid? documentTypeUnique, out bool isActualContent)
-        {
-            isActualContent = false;
-
-            if (!_umbracoContextAccessor.TryGetUmbracoContext(out IUmbracoContext? context))
-                return null;
-
-            IPublishedContent? content = null;
-
-            if (nodeKey.HasValue)
-            {
-                content = context.Content?.GetById(preview: true, nodeKey.GetValueOrDefault());
-            }
-
-            if (content != null)
-            {
-                isActualContent = true;
-                return content;
-            }
-
-            var publishedContentType = _contentTypeCache.Get(PublishedItemType.Content, documentTypeUnique.GetValueOrDefault());
-
-            if (publishedContentType == null)
-                return null;
-
-            var contentCacheKey = string.Format(Constants.CacheKeys.Content, nodeKey);
-            using var scope = _scopeProvider.CreateScope();
-            var cacheItem = _runtimeCache.GetCacheItem(contentCacheKey, () =>
-            {
-                return _documentCacheService.GetByContentType(publishedContentType).FirstOrDefault();
-            }, CacheDuration);
-            scope.Complete();
-            return cacheItem;
-        }
-
-        private static string CleanUpMarkup(string markup)
-        {
-            if (string.IsNullOrWhiteSpace(markup))
-                return markup;
-
-            var content = new HtmlDocument();
-            content.LoadHtml(markup);
-
-            // make sure links are not clickable in the back office, because this will prevent editing
-            var links = content.DocumentNode.SelectNodes("//a");
-
-            if (links != null)
-            {
-                foreach (var link in links)
-                {
-                    link.SetAttributeValue("href", "javascript:;");
-                    link.SetAttributeValue("data-block-preview-link", "true");
-                }
-            }
-
-            // disable forms so they can't be submitted via tab
-            var formElements = content.DocumentNode.SelectNodes("//input | //textarea | //select | //button");
-            if (formElements != null)
-            {
-                foreach (var formElement in formElements)
-                {
-                    formElement.SetAttributeValue("disabled", "disabled");
-                }
-            }
-
-            return content.DocumentNode.OuterHtml;
-        }
         #endregion
     }
 }

--- a/src/Umbraco.Community.BlockPreview/Controllers/BlockPreviewApiController.cs
+++ b/src/Umbraco.Community.BlockPreview/Controllers/BlockPreviewApiController.cs
@@ -1,16 +1,13 @@
 ﻿using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Cache;
-using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Community.BlockPreview.Enums;
 using Umbraco.Community.BlockPreview.Interfaces;
-using Umbraco.Community.BlockPreview.Services;
 using Umbraco.Extensions;
 
 namespace Umbraco.Community.BlockPreview.Controllers
@@ -56,6 +53,19 @@ namespace Umbraco.Community.BlockPreview.Controllers
 
         #region Public
 
+        /// <summary>
+        /// Renders a preview for a grid block using the associated Razor view or ViewComponent.
+        /// </summary>
+        /// <param name="blockData">The JSON content data of the block.</param>
+        /// <param name="nodeKey">The <see cref="Guid"/> that represents the Umbraco node.</param>
+        /// <param name="blockEditorAlias">The alias of the block editor</param>
+        /// <param name="contentElementAlias">The alias of the content being rendered</param>
+        /// <param name="culture">The current culture</param>
+        /// <param name="documentTypeUnique">The <see cref="Guid"/> that represents the Umbraco node</param>
+        /// <param name="contentUdi">The <see cref="Cms.Core.Udi"/> that represents the content element</param>
+        /// <param name="settingsUdi">The <see cref="Cms.Core.Udi"/> that represents the settings element</param>
+        /// <param name="blockIndex">The <see cref="int"/> that represents the block index</param>
+        /// <returns>The markup to render in the preview.</returns>
         [HttpPost("preview/grid")]
         [MapToApiVersion("1.0")]
         [ProducesResponseType(typeof(string), 200)]
@@ -72,6 +82,19 @@ namespace Umbraco.Community.BlockPreview.Controllers
             => RunPreviewAsync(blockData, nodeKey, blockEditorAlias, contentElementAlias, culture,
                 documentTypeUnique, contentUdi, settingsUdi, blockIndex, _blockPreviewService.RenderGridBlock);
 
+        /// <summary>
+        /// Renders a preview for a block list block using the associated Razor view or ViewComponent.
+        /// </summary>
+        /// <param name="blockData">The JSON content data of the block.</param>
+        /// <param name="nodeKey">The key of the node.</param>
+        /// <param name="blockEditorAlias">The alias of the block editor</param>
+        /// <param name="contentElementAlias">The alias of the content being rendered</param>
+        /// <param name="culture">The current culture</param>
+        /// <param name="documentTypeUnique">The <see cref="Guid"/> that represents the Umbraco node</param>
+        /// <param name="contentUdi">The <see cref="Cms.Core.Udi"/> that represents the content element</param>
+        /// <param name="settingsUdi">The <see cref="Cms.Core.Udi"/> that represents the settings element</param>
+        /// <param name="blockIndex">The <see cref="int"/> that represents the block index</param>
+        /// <returns>The markup to render in the preview.</returns>
         [HttpPost("preview/list")]
         [MapToApiVersion("1.0")]
         [ProducesResponseType(typeof(string), 200)]
@@ -88,6 +111,19 @@ namespace Umbraco.Community.BlockPreview.Controllers
             => RunPreviewAsync(blockData, nodeKey, blockEditorAlias, contentElementAlias, culture,
                 documentTypeUnique, contentUdi, settingsUdi, blockIndex, _blockPreviewService.RenderListBlock);
 
+        /// <summary>
+        /// Renders a preview for a single block using the associated Razor view or ViewComponent.
+        /// </summary>
+        /// <param name="blockData">The JSON content data of the block.</param>
+        /// <param name="nodeKey">The key of the node.</param>
+        /// <param name="blockEditorAlias">The alias of the block editor</param>
+        /// <param name="contentElementAlias">The alias of the content being rendered</param>
+        /// <param name="culture">The current culture</param>
+        /// <param name="documentTypeUnique">The <see cref="Guid"/> that represents the Umbraco node</param>
+        /// <param name="contentUdi">The <see cref="Cms.Core.Udi"/> that represents the content element</param>
+        /// <param name="settingsUdi">The <see cref="Cms.Core.Udi"/> that represents the settings element</param>
+        /// <param name="blockIndex">The <see cref="int"/> that represents the block index</param>
+        /// <returns>The markup to render in the preview.</returns>
         [HttpPost("preview/single")]
         [MapToApiVersion("1.0")]
         [ProducesResponseType(typeof(string), 200)]
@@ -104,6 +140,16 @@ namespace Umbraco.Community.BlockPreview.Controllers
             => RunPreviewAsync(blockData, nodeKey, blockEditorAlias, contentElementAlias, culture,
                 documentTypeUnique, contentUdi, settingsUdi, blockIndex, _blockPreviewService.RenderSingleBlock);
 
+        /// <summary>
+        /// Renders a preview for a rich text block using the associated Razor view or ViewComponent.
+        /// </summary>
+        /// <param name="blockData">The JSON content data of the block.</param>
+        /// <param name="nodeKey">The key of the node.</param>
+        /// <param name="blockEditorAlias">The alias of the block editor</param>
+        /// <param name="contentElementAlias">The alias of the content being rendered</param>
+        /// <param name="culture">The current culture</param>
+        /// <param name="documentTypeUnique">The <see cref="Guid"/> that represents the Umbraco node</param>
+        /// <returns>The markup to render in the preview.</returns>
         [HttpPost("preview/rte")]
         [MapToApiVersion("1.0")]
         [ProducesResponseType(typeof(string), 200)]

--- a/src/Umbraco.Community.BlockPreview/Interfaces/IMarkupSanitizer.cs
+++ b/src/Umbraco.Community.BlockPreview/Interfaces/IMarkupSanitizer.cs
@@ -1,0 +1,16 @@
+namespace Umbraco.Community.BlockPreview.Interfaces
+{
+    /// <summary>
+    /// Sanitizes rendered block preview markup before it is sent to the backoffice.
+    /// </summary>
+    public interface IMarkupSanitizer
+    {
+        /// <summary>
+        /// Rewrites anchor hrefs to no-ops and disables form controls so the preview
+        /// cannot navigate away from or submit data within the backoffice.
+        /// </summary>
+        /// <param name="markup">The rendered block markup.</param>
+        /// <returns>The sanitized markup.</returns>
+        string CleanUp(string markup);
+    }
+}

--- a/src/Umbraco.Community.BlockPreview/Interfaces/IPreviewContentResolver.cs
+++ b/src/Umbraco.Community.BlockPreview/Interfaces/IPreviewContentResolver.cs
@@ -16,7 +16,7 @@ namespace Umbraco.Community.BlockPreview.Interfaces
         /// <summary>
         /// Resolves the culture to render with: the requested culture, then the content's
         /// domain culture, then the sole configured language, then the default language.
-        /// Also sets the resolved culture on <see cref="ContextCultureService"/>.
+        /// Also sets the resolved culture on <see cref="Umbraco.Community.BlockPreview.Services.ContextCultureService"/>.
         /// </summary>
         Task<string?> ResolveCultureAsync(string? requestedCulture, IPublishedContent? content);
 

--- a/src/Umbraco.Community.BlockPreview/Interfaces/IPreviewContentResolver.cs
+++ b/src/Umbraco.Community.BlockPreview/Interfaces/IPreviewContentResolver.cs
@@ -22,8 +22,8 @@ namespace Umbraco.Community.BlockPreview.Interfaces
 
         /// <summary>
         /// Builds and assigns a <c>PublishedRequest</c> on the current Umbraco context so
-        /// downstream rendering sees the given culture and content.
+        /// downstream rendering sees the given content.
         /// </summary>
-        Task SetupPublishedRequestAsync(string? culture, IPublishedContent? content, Uri requestUrl);
+        Task SetupPublishedRequestAsync(IPublishedContent? content, Uri requestUrl);
     }
 }

--- a/src/Umbraco.Community.BlockPreview/Interfaces/IPreviewContentResolver.cs
+++ b/src/Umbraco.Community.BlockPreview/Interfaces/IPreviewContentResolver.cs
@@ -1,0 +1,29 @@
+using Umbraco.Cms.Core.Models.PublishedContent;
+
+namespace Umbraco.Community.BlockPreview.Interfaces
+{
+    /// <summary>
+    /// Resolves the published content, culture, and published request for a block preview.
+    /// </summary>
+    public interface IPreviewContentResolver
+    {
+        /// <summary>
+        /// Resolves the content being previewed, preferring an actual node by key and
+        /// falling back to a placeholder node of the given document type.
+        /// </summary>
+        IPublishedContent? Resolve(Guid? nodeKey, Guid? documentTypeUnique, out bool isActualContent);
+
+        /// <summary>
+        /// Resolves the culture to render with: the requested culture, then the content's
+        /// domain culture, then the sole configured language, then the default language.
+        /// Also sets the resolved culture on <see cref="ContextCultureService"/>.
+        /// </summary>
+        Task<string?> ResolveCultureAsync(string? requestedCulture, IPublishedContent? content);
+
+        /// <summary>
+        /// Builds and assigns a <c>PublishedRequest</c> on the current Umbraco context so
+        /// downstream rendering sees the given culture and content.
+        /// </summary>
+        Task SetupPublishedRequestAsync(string? culture, IPublishedContent? content, Uri requestUrl);
+    }
+}

--- a/src/Umbraco.Community.BlockPreview/Interfaces/IPreviewRequestExecutor.cs
+++ b/src/Umbraco.Community.BlockPreview/Interfaces/IPreviewRequestExecutor.cs
@@ -1,0 +1,41 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Core.Models.PublishedContent;
+
+namespace Umbraco.Community.BlockPreview.Interfaces
+{
+    /// <summary>
+    /// The inputs common to every "preview/*" controller action.
+    /// </summary>
+    public sealed record PreviewRenderRequest(
+        string BlockData,
+        Guid NodeKey,
+        string BlockEditorAlias,
+        string ContentElementAlias,
+        string? Culture,
+        Guid DocumentTypeUnique,
+        string? ContentUdi,
+        string? SettingsUdi,
+        int? BlockIndex,
+        HttpContext HttpContext,
+        ControllerContext ControllerContext);
+
+    /// <summary>
+    /// Runs the shared preview request pipeline: verify generated models exist, resolve
+    /// content and culture, enrich the request, invoke the block-type-specific renderer,
+    /// enrich the response, and fall back to an error template on any failure.
+    /// </summary>
+    public interface IPreviewRequestExecutor
+    {
+        /// <param name="request">The common preview request inputs.</param>
+        /// <param name="render">
+        /// The block-type-specific render call, e.g. <c>blockPreviewService.RenderGridBlock</c>.
+        /// Parameters match <see cref="IBlockPreviewService.RenderGridBlock"/>'s order:
+        /// (blockData, content, controllerContext, blockEditorAlias, documentTypeUnique, contentKey, settingsKey, blockIndex).
+        /// </param>
+        /// <returns>The rendered (unsanitized) markup, or an error/warning template.</returns>
+        Task<string> ExecuteAsync(
+            PreviewRenderRequest request,
+            Func<string, IPublishedContent, ControllerContext, string, Guid, string, string?, int?, Task<string>> render);
+    }
+}

--- a/src/Umbraco.Community.BlockPreview/Interfaces/IPreviewRequestExecutor.cs
+++ b/src/Umbraco.Community.BlockPreview/Interfaces/IPreviewRequestExecutor.cs
@@ -7,6 +7,17 @@ namespace Umbraco.Community.BlockPreview.Interfaces
     /// <summary>
     /// The inputs common to every "preview/*" controller action.
     /// </summary>
+    /// <param name="BlockData">The JSON content data of the block.</param>
+    /// <param name="NodeKey">The <see cref="Guid"/> that represents the Umbraco node.</param>
+    /// <param name="BlockEditorAlias">The alias of the block editor.</param>
+    /// <param name="ContentElementAlias">The alias of the content being rendered.</param>
+    /// <param name="Culture">The requested render culture.</param>
+    /// <param name="DocumentTypeUnique">The <see cref="Guid"/> that represents the Umbraco document type.</param>
+    /// <param name="ContentUdi">The <see cref="Cms.Core.Udi"/> that represents the content element.</param>
+    /// <param name="SettingsUdi">The <see cref="Cms.Core.Udi"/> that represents the settings element.</param>
+    /// <param name="BlockIndex">The <see cref="int"/> that represents the block index.</param>
+    /// <param name="HttpContext">The current HTTP context.</param>
+    /// <param name="ControllerContext">The current controller context.</param>
     public sealed record PreviewRenderRequest(
         string BlockData,
         Guid NodeKey,
@@ -27,6 +38,9 @@ namespace Umbraco.Community.BlockPreview.Interfaces
     /// </summary>
     public interface IPreviewRequestExecutor
     {
+        /// <summary>
+        /// Runs the shared preview request pipeline for a single controller action.
+        /// </summary>
         /// <param name="request">The common preview request inputs.</param>
         /// <param name="render">
         /// The block-type-specific render call, e.g. <c>blockPreviewService.RenderGridBlock</c>.

--- a/src/Umbraco.Community.BlockPreview/Services/BlockPreviewService.cs
+++ b/src/Umbraco.Community.BlockPreview/Services/BlockPreviewService.cs
@@ -209,34 +209,12 @@ namespace Umbraco.Community.BlockPreview.Services
 
             bool hasNestedBlockGrid = contentData.Values.Any(x => x.EditorAlias == PropertyEditors.Aliases.BlockGrid);
 
-            IPublishedElement? contentElement = _blockDataConverter.ConvertToElement(contentData, content);
-            if (contentElement == null)
-                return string.Format(Constants.ErrorMessages.ErrorTemplate, Constants.ErrorMessages.InvalidContentData);
-
             BlockItemData? settingsData = settingsGuidParsed != Guid.Empty
                 ? blockValue?.BlockValue?.SettingsData.FirstOrDefault(x => x.Key == settingsGuidParsed)
                 : null;
 
-            IPublishedElement? settingsElement = settingsData != null ? _blockDataConverter.ConvertToElement(settingsData, content) : default;
-
-            Type? contentBlockType = FindBlockType(contentElement.ContentType);
-            Type? settingsBlockType = settingsElement != null ? FindBlockType(settingsElement.ContentType) : default;
-
-            if (contentBlockType == null || (settingsElement != null && settingsBlockType == null))
-                return GetNoModelsErrorMessage();
-
-            BlockGridItem? blockInstance = _blockModelFactory.CreateBlockInstance(
-                BlockType.BlockGrid,
-                contentBlockType, contentElement,
-                settingsBlockType, settingsElement,
-                contentData.Key, settingsData?.Key
-            ) as BlockGridItem;
-
-            if (blockInstance == null)
-                return string.Format(Constants.ErrorMessages.ErrorTemplate, Constants.ErrorMessages.InvalidBlockInstance);
-
             var layoutItems = blockValue?.BlockValue?.GetLayouts();
-            BlockGridLayoutItem? matchingLayout = GetMatchingGridLayout(layoutItems!, blockInstance);
+            BlockGridLayoutItem? matchingLayout = GetMatchingGridLayout(layoutItems!, contentData.Key, out int? matchedRowSpan, out int? matchedColumnSpan);
 
             IContentType? documentType = await _blockTypeCacheService.GetContentType(documentTypeUnique);
             if (documentType == null)
@@ -263,18 +241,21 @@ namespace Umbraco.Community.BlockPreview.Services
             if (matchingBlockConfig == null)
                 return string.Format(Constants.ErrorMessages.ErrorTemplate, Constants.ErrorMessages.InvalidMatchingBlockGridConfiguration);
 
-            BlockPreviewContext previewContext = new BlockPreviewContext(
-               controllerContext,
-               content,
-               contentElement.ContentType.Alias,
-               BlockType.BlockGrid,
-               blockIndex,
-               matchingBlockConfig);
+            return await RenderTypedBlockAsync<BlockGridItem>(
+                BlockType.BlockGrid, contentData, settingsData, content, controllerContext, blockIndex,
+                blockGridBlockConfig: matchingBlockConfig, hasNestedBlockGrid: hasNestedBlockGrid,
+                configure: instance =>
+                {
+                    // Preserves GetMatchingGridLayout's previous side effect of mutating the block
+                    // instance's RowSpan/ColumnSpan directly (now that instance creation happens
+                    // inside the shared helper, the matched spans are threaded through here instead).
+                    if (matchedRowSpan.HasValue)
+                        instance.RowSpan = matchedRowSpan.Value;
+                    if (matchedColumnSpan.HasValue)
+                        instance.ColumnSpan = matchedColumnSpan.Value;
 
-            ConfigureBlockInstanceAreas(blockValue!, blockInstance, config, matchingBlockConfig, matchingLayout!, content);
-
-            previewContext.ViewData = await CreateViewDataAsync(blockInstance, previewContext, hasNestedBlockGrid);
-            return await GetMarkup(previewContext);
+                    ConfigureBlockInstanceAreas(blockValue!, instance, config, matchingBlockConfig, matchingLayout!, content);
+                });
         }
 
         /// <summary>
@@ -315,44 +296,12 @@ namespace Umbraco.Community.BlockPreview.Services
             Guid.TryParse(settingsKey!, out Guid settingsGuidParsed);
 
             BlockItemData? contentData = blockValue?.BlockValue?.ContentData.FirstOrDefault(x => x.Key == contentGuidParsed);
-            if (contentData == null)
-                return string.Format(Constants.ErrorMessages.ErrorTemplate, Constants.ErrorMessages.InvalidContentData);
-
-            IPublishedElement? contentElement = _blockDataConverter.ConvertToElement(contentData, content);
-            if (contentElement == null)
-                return string.Format(Constants.ErrorMessages.ErrorTemplate, Constants.ErrorMessages.InvalidContentData);
-
             BlockItemData? settingsData = settingsGuidParsed != Guid.Empty
                 ? blockValue?.BlockValue?.SettingsData.FirstOrDefault(x => x.Key == settingsGuidParsed)
                 : null;
 
-            IPublishedElement? settingsElement = settingsData != null ? _blockDataConverter.ConvertToElement(settingsData, content) : default;
-
-            Type? contentBlockType = FindBlockType(contentElement.ContentType);
-            Type? settingsBlockType = settingsElement != null ? FindBlockType(settingsElement.ContentType) : default;
-
-            if (contentBlockType == null || (settingsElement != null && settingsBlockType == null))
-                return GetNoModelsErrorMessage();
-
-            BlockListItem? blockInstance = _blockModelFactory.CreateBlockInstance(
-                BlockType.BlockList,
-                contentBlockType, contentElement,
-                settingsBlockType, settingsElement,
-                contentData.Key, settingsData?.Key
-            ) as BlockListItem;
-
-            if (blockInstance == null)
-                return string.Format(Constants.ErrorMessages.ErrorTemplate, Constants.ErrorMessages.InvalidBlockInstance);
-
-            BlockPreviewContext previewContext = new BlockPreviewContext(
-               controllerContext,
-               content,
-               contentElement.ContentType.Alias,
-               BlockType.BlockList,
-               blockIndex);
-
-            previewContext.ViewData = await CreateViewDataAsync(blockInstance, previewContext);
-            return await GetMarkup(previewContext);
+            return await RenderTypedBlockAsync<BlockListItem>(
+                BlockType.BlockList, contentData, settingsData, content, controllerContext, blockIndex);
         }
 
         /// <summary>
@@ -393,44 +342,13 @@ namespace Umbraco.Community.BlockPreview.Services
             Guid.TryParse(settingsKey!, out Guid settingsGuidParsed);
 
             BlockItemData? contentData = blockValue?.BlockValue?.ContentData.FirstOrDefault(x => x.Key == contentGuidParsed);
-            if (contentData == null)
-                return string.Format(Constants.ErrorMessages.ErrorTemplate, Constants.ErrorMessages.InvalidContentData);
-
-            IPublishedElement? contentElement = _blockDataConverter.ConvertToElement(contentData, content);
-            if (contentElement == null)
-                return string.Format(Constants.ErrorMessages.ErrorTemplate, Constants.ErrorMessages.InvalidContentData);
-
             BlockItemData? settingsData = settingsGuidParsed != Guid.Empty
                 ? blockValue?.BlockValue?.SettingsData.FirstOrDefault(x => x.Key == settingsGuidParsed)
                 : null;
 
-            IPublishedElement? settingsElement = settingsData != null ? _blockDataConverter.ConvertToElement(settingsData, content) : default;
-
-            Type? contentBlockType = FindBlockType(contentElement.ContentType);
-            Type? settingsBlockType = settingsElement != null ? FindBlockType(settingsElement.ContentType) : default;
-
-            if (contentBlockType == null || (settingsElement != null && settingsBlockType == null))
-                return GetNoModelsErrorMessage();
-
-            BlockListItem? blockInstance = _blockModelFactory.CreateBlockInstance(
-                BlockType.SingleBlock,
-                contentBlockType, contentElement,
-                settingsBlockType, settingsElement,
-                contentData.Key, settingsData?.Key
-            ) as BlockListItem;
-
-            if (blockInstance == null)
-                return string.Format(Constants.ErrorMessages.ErrorTemplate, Constants.ErrorMessages.InvalidBlockInstance);
-
-            BlockPreviewContext previewContext = new BlockPreviewContext(
-               controllerContext,
-               content,
-               contentElement.ContentType.Alias,
-               BlockType.SingleBlock,
-               blockIndex);
-
-            previewContext.ViewData = await CreateViewDataAsync(blockInstance, previewContext);
-            return await GetMarkup(previewContext);
+            // Historically cast to BlockListItem (Single Block reuses the List model shape) — preserved.
+            return await RenderTypedBlockAsync<BlockListItem>(
+                BlockType.SingleBlock, contentData, settingsData, content, controllerContext, blockIndex);
         }
 
         /// <summary>
@@ -456,40 +374,10 @@ namespace Umbraco.Community.BlockPreview.Services
             }
 
             BlockItemData? contentData = blockValue?.BlockValue?.ContentData.FirstOrDefault();
-            if (contentData == null)
-                return string.Format(Constants.ErrorMessages.ErrorTemplate, Constants.ErrorMessages.InvalidContentData);
-
-            IPublishedElement? contentElement = _blockDataConverter.ConvertToElement(contentData, content);
-            if (contentElement == null)
-                return string.Format(Constants.ErrorMessages.ErrorTemplate, Constants.ErrorMessages.InvalidContentData);
-
             BlockItemData? settingsData = blockValue?.BlockValue.SettingsData.FirstOrDefault();
-            IPublishedElement? settingsElement = settingsData != null ? _blockDataConverter.ConvertToElement(settingsData, content) : default;
 
-            Type? contentBlockType = FindBlockType(contentElement.ContentType);
-            Type? settingsBlockType = settingsElement != null ? FindBlockType(settingsElement.ContentType) : default;
-
-            if (contentBlockType == null || (settingsElement != null && settingsBlockType == null))
-                return GetNoModelsErrorMessage();
-
-            RichTextBlockItem? blockInstance = _blockModelFactory.CreateBlockInstance(
-                BlockType.RichText,
-                contentBlockType, contentElement,
-                settingsBlockType, settingsElement,
-                contentData.Key, settingsData?.Key
-            ) as RichTextBlockItem;
-
-            if (blockInstance == null)
-                return string.Format(Constants.ErrorMessages.ErrorTemplate, Constants.ErrorMessages.InvalidBlockInstance);
-
-            BlockPreviewContext previewContext = new BlockPreviewContext(
-                controllerContext,
-                content,
-                contentElement.ContentType.Alias,
-                BlockType.RichText);
-
-            previewContext.ViewData = await CreateViewDataAsync(blockInstance, previewContext);
-            return await GetMarkup(previewContext);
+            return await RenderTypedBlockAsync<RichTextBlockItem>(
+                BlockType.RichText, contentData, settingsData, content, controllerContext, blockIndex: null);
         }
 
         /// <inheritdoc/>
@@ -579,17 +467,27 @@ namespace Umbraco.Community.BlockPreview.Services
             return string.Format(Constants.ErrorMessages.WarningTemplate, errorMessage);
         }
 
-        private BlockGridLayoutItem? GetMatchingGridLayout(IEnumerable<BlockGridLayoutItem> layoutItems, BlockGridItem? blockInstance)
+        /// <summary>
+        /// Finds the layout item matching <paramref name="contentKey"/> — either a top-level layout
+        /// item or one nested inside an area — and reports the row/column span that should be applied
+        /// to the corresponding block instance. Only set when a match is found (mirroring the previous
+        /// behavior of mutating the block instance directly, before the block instance existed at this
+        /// point in the pipeline).
+        /// </summary>
+        private BlockGridLayoutItem? GetMatchingGridLayout(IEnumerable<BlockGridLayoutItem> layoutItems, Guid contentKey, out int? matchedRowSpan, out int? matchedColumnSpan)
         {
-            if (layoutItems == null || blockInstance == null)
+            matchedRowSpan = null;
+            matchedColumnSpan = null;
+
+            if (layoutItems == null)
                 return null;
 
             foreach (var layoutItem in layoutItems)
             {
-                if (layoutItem.ContentKey == blockInstance.ContentKey)
+                if (layoutItem.ContentKey == contentKey)
                 {
-                    blockInstance.RowSpan = layoutItem.RowSpan ?? 1;
-                    blockInstance.ColumnSpan = layoutItem.ColumnSpan ?? 12;
+                    matchedRowSpan = layoutItem.RowSpan ?? 1;
+                    matchedColumnSpan = layoutItem.ColumnSpan ?? 12;
                     return layoutItem;
                 }
                 else
@@ -598,9 +496,9 @@ namespace Umbraco.Community.BlockPreview.Services
                     {
                         foreach (var item in area.Items)
                         {
-                            if (item.ContentKey != blockInstance.ContentKey) continue;
-                            blockInstance.RowSpan = item.RowSpan ?? 1;
-                            blockInstance.ColumnSpan = item.ColumnSpan ?? layoutItem.ColumnSpan ?? 12;
+                            if (item.ContentKey != contentKey) continue;
+                            matchedRowSpan = item.RowSpan ?? 1;
+                            matchedColumnSpan = item.ColumnSpan ?? layoutItem.ColumnSpan ?? 12;
                             return layoutItem;
                         }
                     }
@@ -672,6 +570,66 @@ namespace Umbraco.Community.BlockPreview.Services
             // Try custom view resolution first (via virtual GetViewResult for extensibility)
             var viewResult = GetViewResult(context);
             return await _blockViewRenderer.RenderAsync(context, viewResult);
+        }
+
+        /// <summary>
+        /// Shared tail for all block render methods: converts content/settings data to published
+        /// elements, resolves their model types, creates the typed block instance, optionally
+        /// mutates it (e.g. Block Grid area configuration), builds the view data, and renders markup.
+        /// </summary>
+        /// <typeparam name="TBlockItem">The typed block item to cast the created instance to.</typeparam>
+        /// <param name="blockType">The type of block editor being rendered.</param>
+        /// <param name="contentData">The block's content data, or null if not found.</param>
+        /// <param name="settingsData">The block's settings data, or null if there is none.</param>
+        /// <param name="content">The published content associated with the block.</param>
+        /// <param name="controllerContext">The controller context for the current request.</param>
+        /// <param name="blockIndex">The index of the block within its container, if applicable.</param>
+        /// <param name="blockGridBlockConfig">The Block Grid block configuration, if applicable.</param>
+        /// <param name="hasNestedBlockGrid">Indicates whether the block contains a nested block grid.</param>
+        /// <param name="configure">An optional callback to mutate the block instance before view data is built (e.g. <see cref="ConfigureBlockInstanceAreas"/>).</param>
+        /// <returns>The rendered HTML, or an error message if any step fails.</returns>
+        private async Task<string> RenderTypedBlockAsync<TBlockItem>(
+            BlockType blockType,
+            BlockItemData? contentData,
+            BlockItemData? settingsData,
+            IPublishedContent content,
+            ControllerContext controllerContext,
+            int? blockIndex,
+            BlockGridConfiguration.BlockGridBlockConfiguration? blockGridBlockConfig = null,
+            bool hasNestedBlockGrid = false,
+            Action<TBlockItem>? configure = null)
+            where TBlockItem : class
+        {
+            if (contentData == null)
+                return string.Format(Constants.ErrorMessages.ErrorTemplate, Constants.ErrorMessages.InvalidContentData);
+
+            IPublishedElement? contentElement = _blockDataConverter.ConvertToElement(contentData, content);
+            if (contentElement == null)
+                return string.Format(Constants.ErrorMessages.ErrorTemplate, Constants.ErrorMessages.InvalidContentData);
+
+            IPublishedElement? settingsElement = settingsData != null ? _blockDataConverter.ConvertToElement(settingsData, content) : default;
+
+            Type? contentBlockType = FindBlockType(contentElement.ContentType);
+            Type? settingsBlockType = settingsElement != null ? FindBlockType(settingsElement.ContentType) : default;
+
+            if (contentBlockType == null || (settingsElement != null && settingsBlockType == null))
+                return GetNoModelsErrorMessage();
+
+            TBlockItem? blockInstance = _blockModelFactory.CreateBlockInstance(
+                blockType, contentBlockType, contentElement, settingsBlockType, settingsElement,
+                contentData.Key, settingsData?.Key
+            ) as TBlockItem;
+
+            if (blockInstance == null)
+                return string.Format(Constants.ErrorMessages.ErrorTemplate, Constants.ErrorMessages.InvalidBlockInstance);
+
+            configure?.Invoke(blockInstance);
+
+            BlockPreviewContext previewContext = new BlockPreviewContext(
+                controllerContext, content, contentElement.ContentType.Alias, blockType, blockIndex, blockGridBlockConfig);
+
+            previewContext.ViewData = await CreateViewDataAsync(blockInstance, previewContext, hasNestedBlockGrid);
+            return await GetMarkup(previewContext);
         }
 
         private void ConfigureBlockInstanceAreas(

--- a/src/Umbraco.Community.BlockPreview/Services/BlockPreviewService.cs
+++ b/src/Umbraco.Community.BlockPreview/Services/BlockPreviewService.cs
@@ -447,7 +447,17 @@ namespace Umbraco.Community.BlockPreview.Services
         #endregion
 
         #region Private
-        private Type? FindBlockType(IPublishedContentType? contentType)
+        /// <summary>
+        /// Resolves the strongly-typed model type for a published content type, via
+        /// <see cref="BlockEditorConverter.GetModelType"/>.
+        /// </summary>
+        /// <param name="contentType">The published content type to resolve a model type for.</param>
+        /// <returns>The resolved model type, or <see langword="null"/> if no generated model exists.</returns>
+        /// <remarks>
+        /// Protected and virtual so tests can override this without going through the real
+        /// (unmockable, <c>sealed</c>) <see cref="BlockEditorConverter"/>.
+        /// </remarks>
+        protected virtual Type? FindBlockType(IPublishedContentType? contentType)
         {
             if (contentType == null)
                 return null;

--- a/src/Umbraco.Community.BlockPreview/Services/MarkupSanitizer.cs
+++ b/src/Umbraco.Community.BlockPreview/Services/MarkupSanitizer.cs
@@ -1,0 +1,43 @@
+using HtmlAgilityPack;
+using Umbraco.Community.BlockPreview.Interfaces;
+
+namespace Umbraco.Community.BlockPreview.Services
+{
+    /// <inheritdoc cref="IMarkupSanitizer" />
+    public class MarkupSanitizer : IMarkupSanitizer
+    {
+        /// <inheritdoc />
+        public string CleanUp(string markup)
+        {
+            if (string.IsNullOrWhiteSpace(markup))
+                return markup;
+
+            var content = new HtmlDocument();
+            content.LoadHtml(markup);
+
+            // make sure links are not clickable in the back office, because this will prevent editing
+            var links = content.DocumentNode.SelectNodes("//a");
+
+            if (links != null)
+            {
+                foreach (var link in links)
+                {
+                    link.SetAttributeValue("href", "javascript:;");
+                    link.SetAttributeValue("data-block-preview-link", "true");
+                }
+            }
+
+            // disable forms so they can't be submitted via tab
+            var formElements = content.DocumentNode.SelectNodes("//input | //textarea | //select | //button");
+            if (formElements != null)
+            {
+                foreach (var formElement in formElements)
+                {
+                    formElement.SetAttributeValue("disabled", "disabled");
+                }
+            }
+
+            return content.DocumentNode.OuterHtml;
+        }
+    }
+}

--- a/src/Umbraco.Community.BlockPreview/Services/PreviewContentResolver.cs
+++ b/src/Umbraco.Community.BlockPreview/Services/PreviewContentResolver.cs
@@ -25,6 +25,9 @@ namespace Umbraco.Community.BlockPreview.Services
 
         private static readonly TimeSpan CacheDuration = TimeSpan.FromHours(1);
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PreviewContentResolver"/> class.
+        /// </summary>
         public PreviewContentResolver(
             IUmbracoContextAccessor umbracoContextAccessor,
             IPublishedRouter publishedRouter,
@@ -105,7 +108,7 @@ namespace Umbraco.Community.BlockPreview.Services
         }
 
         /// <inheritdoc />
-        public async Task SetupPublishedRequestAsync(string? culture, IPublishedContent? content, Uri requestUrl)
+        public async Task SetupPublishedRequestAsync(IPublishedContent? content, Uri requestUrl)
         {
             if (!_umbracoContextAccessor.TryGetUmbracoContext(out IUmbracoContext? context))
                 return;

--- a/src/Umbraco.Community.BlockPreview/Services/PreviewContentResolver.cs
+++ b/src/Umbraco.Community.BlockPreview/Services/PreviewContentResolver.cs
@@ -1,0 +1,121 @@
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.PublishedCache;
+using Umbraco.Cms.Core.Routing;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Web;
+using Umbraco.Cms.Infrastructure.HybridCache;
+using Umbraco.Cms.Infrastructure.Scoping;
+using Umbraco.Community.BlockPreview.Interfaces;
+using Umbraco.Extensions;
+
+namespace Umbraco.Community.BlockPreview.Services
+{
+    /// <inheritdoc cref="IPreviewContentResolver" />
+    public class PreviewContentResolver : IPreviewContentResolver
+    {
+        private readonly IUmbracoContextAccessor _umbracoContextAccessor;
+        private readonly IPublishedRouter _publishedRouter;
+        private readonly ILanguageService _languageService;
+        private readonly ContextCultureService _contextCultureService;
+        private readonly IPublishedContentTypeCache _contentTypeCache;
+        private readonly IDocumentCacheService _documentCacheService;
+        private readonly IScopeProvider _scopeProvider;
+        private readonly IAppPolicyCache _runtimeCache;
+
+        private static readonly TimeSpan CacheDuration = TimeSpan.FromHours(1);
+
+        public PreviewContentResolver(
+            IUmbracoContextAccessor umbracoContextAccessor,
+            IPublishedRouter publishedRouter,
+            ILanguageService languageService,
+            ContextCultureService contextCultureService,
+            IPublishedContentTypeCache contentTypeCache,
+            IDocumentCacheService documentCacheService,
+            IScopeProvider scopeProvider,
+            IAppPolicyCache runtimeCache)
+        {
+            _umbracoContextAccessor = umbracoContextAccessor;
+            _publishedRouter = publishedRouter;
+            _languageService = languageService;
+            _contextCultureService = contextCultureService;
+            _contentTypeCache = contentTypeCache;
+            _documentCacheService = documentCacheService;
+            _scopeProvider = scopeProvider;
+            _runtimeCache = runtimeCache;
+        }
+
+        /// <inheritdoc />
+        public IPublishedContent? Resolve(Guid? nodeKey, Guid? documentTypeUnique, out bool isActualContent)
+        {
+            isActualContent = false;
+
+            if (!_umbracoContextAccessor.TryGetUmbracoContext(out IUmbracoContext? context))
+                return null;
+
+            IPublishedContent? content = null;
+
+            if (nodeKey.HasValue)
+            {
+                content = context.Content?.GetById(preview: true, nodeKey.GetValueOrDefault());
+            }
+
+            if (content != null)
+            {
+                isActualContent = true;
+                return content;
+            }
+
+            var publishedContentType = _contentTypeCache.Get(PublishedItemType.Content, documentTypeUnique.GetValueOrDefault());
+
+            if (publishedContentType == null)
+                return null;
+
+            var contentCacheKey = string.Format(Constants.CacheKeys.Content, nodeKey);
+            using var scope = _scopeProvider.CreateScope();
+            var cacheItem = _runtimeCache.GetCacheItem(contentCacheKey, () =>
+            {
+                return _documentCacheService.GetByContentType(publishedContentType).FirstOrDefault();
+            }, CacheDuration);
+            scope.Complete();
+            return cacheItem;
+        }
+
+        /// <inheritdoc />
+        public async Task<string?> ResolveCultureAsync(string? requestedCulture, IPublishedContent? content)
+        {
+            var currentCulture = string.IsNullOrWhiteSpace(requestedCulture) || requestedCulture == "undefined"
+                ? null
+                : requestedCulture;
+
+            currentCulture ??= content?.GetCultureFromDomains();
+
+            if (string.IsNullOrEmpty(currentCulture))
+            {
+                var allLanguages = await _languageService.GetAllAsync();
+                var languages = allLanguages.ToList();
+                currentCulture = languages.Count == 1
+                    ? languages[0].IsoCode
+                    : await _languageService.GetDefaultIsoCodeAsync();
+            }
+
+            _contextCultureService.SetCulture(currentCulture);
+
+            return currentCulture;
+        }
+
+        /// <inheritdoc />
+        public async Task SetupPublishedRequestAsync(string? culture, IPublishedContent? content, Uri requestUrl)
+        {
+            if (!_umbracoContextAccessor.TryGetUmbracoContext(out IUmbracoContext? context))
+                return;
+
+            var requestBuilder = await _publishedRouter.CreateRequestAsync(requestUrl);
+
+            if (content != null)
+                requestBuilder.SetPublishedContent(content);
+
+            context.PublishedRequest = requestBuilder.Build();
+        }
+    }
+}

--- a/src/Umbraco.Community.BlockPreview/Services/PreviewRequestExecutor.cs
+++ b/src/Umbraco.Community.BlockPreview/Services/PreviewRequestExecutor.cs
@@ -52,10 +52,11 @@ namespace Umbraco.Community.BlockPreview.Services
             {
                 IPublishedContent? content = _contentResolver.Resolve(request.NodeKey, request.DocumentTypeUnique, out bool isActualContent);
 
-                string? currentCulture = await _contentResolver.ResolveCultureAsync(request.Culture, content);
+                // The resolved culture is applied as a side effect on ContextCultureService;
+                // downstream rendering picks it up from there rather than from a return value.
+                await _contentResolver.ResolveCultureAsync(request.Culture, content);
 
                 await _contentResolver.SetupPublishedRequestAsync(
-                    currentCulture,
                     isActualContent ? content : null,
                     new Uri(request.HttpContext.Request.GetDisplayUrl()));
 

--- a/src/Umbraco.Community.BlockPreview/Services/PreviewRequestExecutor.cs
+++ b/src/Umbraco.Community.BlockPreview/Services/PreviewRequestExecutor.cs
@@ -1,0 +1,90 @@
+using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Community.BlockPreview.Interfaces;
+using Umbraco.Extensions;
+
+namespace Umbraco.Community.BlockPreview.Services
+{
+    /// <inheritdoc cref="IPreviewRequestExecutor" />
+    public class PreviewRequestExecutor : IPreviewRequestExecutor
+    {
+        private readonly IPreviewContentResolver _contentResolver;
+        private readonly IBlockPreviewRequestEnricher _requestEnricher;
+        private readonly IBlockPreviewResponseEnricher _responseEnricher;
+        private readonly IAppPolicyCache _runtimeCache;
+        private readonly ITypeFinder _typeFinder;
+        private readonly ILogger<PreviewRequestExecutor> _logger;
+
+        private static readonly TimeSpan CacheDuration = TimeSpan.FromHours(1);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PreviewRequestExecutor"/> class.
+        /// </summary>
+        public PreviewRequestExecutor(
+            IPreviewContentResolver contentResolver,
+            IBlockPreviewRequestEnricher requestEnricher,
+            IBlockPreviewResponseEnricher responseEnricher,
+            IAppPolicyCache runtimeCache,
+            ITypeFinder typeFinder,
+            ILogger<PreviewRequestExecutor> logger)
+        {
+            _contentResolver = contentResolver;
+            _requestEnricher = requestEnricher;
+            _responseEnricher = responseEnricher;
+            _runtimeCache = runtimeCache;
+            _typeFinder = typeFinder;
+            _logger = logger;
+        }
+
+        /// <inheritdoc />
+        public async Task<string> ExecuteAsync(
+            PreviewRenderRequest request,
+            Func<string, IPublishedContent, ControllerContext, string, Guid, string, string?, int?, Task<string>> render)
+        {
+            if (!CheckGeneratedModelsExist())
+                return string.Format(Constants.ErrorMessages.WarningTemplate, Constants.ErrorMessages.ModelsBuilderError);
+
+            try
+            {
+                IPublishedContent? content = _contentResolver.Resolve(request.NodeKey, request.DocumentTypeUnique, out bool isActualContent);
+
+                string? currentCulture = await _contentResolver.ResolveCultureAsync(request.Culture, content);
+
+                await _contentResolver.SetupPublishedRequestAsync(
+                    currentCulture,
+                    isActualContent ? content : null,
+                    new Uri(request.HttpContext.Request.GetDisplayUrl()));
+
+                await _requestEnricher.EnrichAsync(
+                    request.HttpContext, content, request.BlockEditorAlias, request.ContentElementAlias,
+                    request.ContentUdi, request.SettingsUdi, request.BlockIndex);
+
+                string markup = await render(
+                    request.BlockData, content!, request.ControllerContext, request.BlockEditorAlias,
+                    request.DocumentTypeUnique, request.ContentUdi ?? string.Empty, request.SettingsUdi, request.BlockIndex);
+
+                return await _responseEnricher.EnrichAsync(
+                    markup, request.HttpContext, content, request.BlockEditorAlias, request.ContentElementAlias,
+                    request.ContentUdi, request.SettingsUdi, request.BlockIndex);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, string.Format(Constants.ErrorMessages.LoggerError, request.ContentElementAlias));
+                return string.Format(Constants.ErrorMessages.ErrorTemplate,
+                    string.Format(Constants.ErrorMessages.RenderError, ex.Message));
+            }
+        }
+
+        private bool CheckGeneratedModelsExist()
+        {
+            return _runtimeCache.GetCacheItem(Constants.CacheKeys.GeneratedModels, () =>
+            {
+                return _typeFinder.FindClassesWithAttribute<PublishedModelAttribute>().Any();
+            }, CacheDuration);
+        }
+    }
+}

--- a/tests/Umbraco.Community.BlockPreview.Tests/Controllers/BlockPreviewApiControllerTests.cs
+++ b/tests/Umbraco.Community.BlockPreview.Tests/Controllers/BlockPreviewApiControllerTests.cs
@@ -73,6 +73,81 @@ public class BlockPreviewApiControllerTests
     }
 
     [Test]
+    public async Task PreviewGridBlock_PassesRenderDelegateThatCallsRenderGridBlock()
+    {
+        // Guards against a method-name swap between PreviewGridBlock/PreviewListBlock/PreviewSingleBlock:
+        // PreviewGridBlock_SanitizesExecutorOutputAndReturnsOk above only checks sanitization, which would
+        // still pass even if the controller wired up the wrong IBlockPreviewService method as the render delegate.
+        Func<string, IPublishedContent, ControllerContext, string, Guid, string, string?, int?, Task<string>>? captured = null;
+        _executor
+            .Setup(e => e.ExecuteAsync(It.IsAny<PreviewRenderRequest>(),
+                It.IsAny<Func<string, IPublishedContent, ControllerContext, string, Guid, string, string?, int?, Task<string>>>()))
+            .Callback<PreviewRenderRequest, Func<string, IPublishedContent, ControllerContext, string, Guid, string, string?, int?, Task<string>>>(
+                (_, render) => captured = render)
+            .ReturnsAsync("<div>grid</div>");
+
+        var content = Mock.Of<IPublishedContent>();
+        _blockPreviewService
+            .Setup(s => s.RenderGridBlock("{}", content, It.IsAny<ControllerContext>(), "ignored", Guid.Empty, "ignored", null, null))
+            .ReturnsAsync("<div>grid-direct</div>");
+
+        await _controller.PreviewGridBlock("{}", Guid.NewGuid(), "myGrid", "myElement");
+
+        Assert.That(captured, Is.Not.Null);
+        var direct = await captured!("{}", content, new ControllerContext(), "ignored", Guid.Empty, "ignored", null, null);
+        Assert.That(direct, Is.EqualTo("<div>grid-direct</div>"));
+        _blockPreviewService.Verify(s => s.RenderGridBlock("{}", content, It.IsAny<ControllerContext>(), "ignored", Guid.Empty, "ignored", null, null), Times.Once);
+    }
+
+    [Test]
+    public async Task PreviewListBlock_PassesRenderDelegateThatCallsRenderListBlock()
+    {
+        Func<string, IPublishedContent, ControllerContext, string, Guid, string, string?, int?, Task<string>>? captured = null;
+        _executor
+            .Setup(e => e.ExecuteAsync(It.IsAny<PreviewRenderRequest>(),
+                It.IsAny<Func<string, IPublishedContent, ControllerContext, string, Guid, string, string?, int?, Task<string>>>()))
+            .Callback<PreviewRenderRequest, Func<string, IPublishedContent, ControllerContext, string, Guid, string, string?, int?, Task<string>>>(
+                (_, render) => captured = render)
+            .ReturnsAsync("<div>list</div>");
+
+        var content = Mock.Of<IPublishedContent>();
+        _blockPreviewService
+            .Setup(s => s.RenderListBlock("{}", content, It.IsAny<ControllerContext>(), "ignored", Guid.Empty, "ignored", null, null))
+            .ReturnsAsync("<div>list-direct</div>");
+
+        await _controller.PreviewListBlock("{}", Guid.NewGuid(), "myList", "myElement");
+
+        Assert.That(captured, Is.Not.Null);
+        var direct = await captured!("{}", content, new ControllerContext(), "ignored", Guid.Empty, "ignored", null, null);
+        Assert.That(direct, Is.EqualTo("<div>list-direct</div>"));
+        _blockPreviewService.Verify(s => s.RenderListBlock("{}", content, It.IsAny<ControllerContext>(), "ignored", Guid.Empty, "ignored", null, null), Times.Once);
+    }
+
+    [Test]
+    public async Task PreviewSingleBlock_PassesRenderDelegateThatCallsRenderSingleBlock()
+    {
+        Func<string, IPublishedContent, ControllerContext, string, Guid, string, string?, int?, Task<string>>? captured = null;
+        _executor
+            .Setup(e => e.ExecuteAsync(It.IsAny<PreviewRenderRequest>(),
+                It.IsAny<Func<string, IPublishedContent, ControllerContext, string, Guid, string, string?, int?, Task<string>>>()))
+            .Callback<PreviewRenderRequest, Func<string, IPublishedContent, ControllerContext, string, Guid, string, string?, int?, Task<string>>>(
+                (_, render) => captured = render)
+            .ReturnsAsync("<div>single</div>");
+
+        var content = Mock.Of<IPublishedContent>();
+        _blockPreviewService
+            .Setup(s => s.RenderSingleBlock("{}", content, It.IsAny<ControllerContext>(), "ignored", Guid.Empty, "ignored", null, null))
+            .ReturnsAsync("<div>single-direct</div>");
+
+        await _controller.PreviewSingleBlock("{}", Guid.NewGuid(), "mySingle", "myElement");
+
+        Assert.That(captured, Is.Not.Null);
+        var direct = await captured!("{}", content, new ControllerContext(), "ignored", Guid.Empty, "ignored", null, null);
+        Assert.That(direct, Is.EqualTo("<div>single-direct</div>"));
+        _blockPreviewService.Verify(s => s.RenderSingleBlock("{}", content, It.IsAny<ControllerContext>(), "ignored", Guid.Empty, "ignored", null, null), Times.Once);
+    }
+
+    [Test]
     public async Task PreviewRichTextMarkup_PassesRenderDelegateThatCallsRenderRichTextBlock()
     {
         Func<string, IPublishedContent, ControllerContext, string, Guid, string, string?, int?, Task<string>>? captured = null;

--- a/tests/Umbraco.Community.BlockPreview.Tests/Controllers/BlockPreviewApiControllerTests.cs
+++ b/tests/Umbraco.Community.BlockPreview.Tests/Controllers/BlockPreviewApiControllerTests.cs
@@ -1,0 +1,120 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Community.BlockPreview.Controllers;
+using Umbraco.Community.BlockPreview.Enums;
+using Umbraco.Community.BlockPreview.Interfaces;
+
+namespace Umbraco.Community.BlockPreview.Tests.Controllers;
+
+[TestFixture]
+public class BlockPreviewApiControllerTests
+{
+    private Mock<IPreviewRequestExecutor> _executor = null!;
+    private Mock<IMarkupSanitizer> _sanitizer = null!;
+    private Mock<IPreviewContentResolver> _contentResolver = null!;
+    private Mock<IBlockPreviewService> _blockPreviewService = null!;
+    private BlockPreviewApiController _controller = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _executor = new Mock<IPreviewRequestExecutor>();
+        _sanitizer = new Mock<IMarkupSanitizer>();
+        _contentResolver = new Mock<IPreviewContentResolver>();
+        _blockPreviewService = new Mock<IBlockPreviewService>();
+
+        _sanitizer.Setup(s => s.CleanUp(It.IsAny<string>())).Returns((string m) => $"clean:{m}");
+
+        // AppCaches has no parameterless constructor, so Mock.Of<AppCaches>() can't proxy it.
+        // Build a real instance from mocked sub-caches instead, matching the pattern already
+        // used in NotificationHandlers/DataTypeSavedNotificationHandlerTests.cs.
+        var appCaches = new AppCaches(
+            Mock.Of<IAppPolicyCache>(),
+            Mock.Of<IRequestCache>(),
+            new IsolatedCaches(_ => Mock.Of<IAppPolicyCache>()));
+
+        _controller = new BlockPreviewApiController(
+            _executor.Object,
+            _sanitizer.Object,
+            _contentResolver.Object,
+            _blockPreviewService.Object,
+            Mock.Of<IOptions<BlockPreviewOptions>>(o => o.Value == new BlockPreviewOptions()),
+            appCaches,
+            Mock.Of<IBlockPreviewRequestEnricher>())
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            }
+        };
+    }
+
+    [TearDown]
+    public void TearDown() => (_controller as IDisposable)?.Dispose();
+
+    [Test]
+    public async Task PreviewGridBlock_SanitizesExecutorOutputAndReturnsOk()
+    {
+        _executor
+            .Setup(e => e.ExecuteAsync(It.IsAny<PreviewRenderRequest>(),
+                It.IsAny<Func<string, IPublishedContent, ControllerContext, string, Guid, string, string?, int?, Task<string>>>()))
+            .ReturnsAsync("<div>grid</div>");
+
+        var result = await _controller.PreviewGridBlock("{}", Guid.NewGuid(), "myGrid", "myElement");
+
+        var ok = result as OkObjectResult;
+        Assert.That(ok, Is.Not.Null);
+        Assert.That(ok!.Value, Is.EqualTo("clean:<div>grid</div>"));
+    }
+
+    [Test]
+    public async Task PreviewRichTextMarkup_PassesRenderDelegateThatCallsRenderRichTextBlock()
+    {
+        Func<string, IPublishedContent, ControllerContext, string, Guid, string, string?, int?, Task<string>>? captured = null;
+        _executor
+            .Setup(e => e.ExecuteAsync(It.IsAny<PreviewRenderRequest>(),
+                It.IsAny<Func<string, IPublishedContent, ControllerContext, string, Guid, string, string?, int?, Task<string>>>()))
+            .Callback<PreviewRenderRequest, Func<string, IPublishedContent, ControllerContext, string, Guid, string, string?, int?, Task<string>>>(
+                (_, render) => captured = render)
+            .ReturnsAsync("<div>rte</div>");
+
+        var content = Mock.Of<IPublishedContent>();
+        _blockPreviewService
+            .Setup(s => s.RenderRichTextBlock("{}", content, It.IsAny<ControllerContext>()))
+            .ReturnsAsync("<div>rte-direct</div>");
+
+        await _controller.PreviewRichTextMarkup("{}", Guid.NewGuid(), "myRte", "myElement");
+
+        Assert.That(captured, Is.Not.Null);
+        var direct = await captured!("{}", content, new ControllerContext(), "ignored", Guid.Empty, "ignored", null, null);
+        Assert.That(direct, Is.EqualTo("<div>rte-direct</div>"));
+    }
+
+    [Test]
+    public async Task GetGridStylesheets_ResolvesContentViaContentResolverThenAsksBlockPreviewService()
+    {
+        var nodeKey = Guid.NewGuid();
+        var docType = Guid.NewGuid();
+        var content = Mock.Of<IPublishedContent>();
+        // IPreviewContentResolver.Resolve's 3rd parameter is `out bool isActualContent`, not an
+        // out IPublishedContent — the resolved content comes back via the return value instead
+        // (matches Task 3's PreviewRequestExecutorTests.cs usage of the same interface).
+        bool isActualContent = true;
+        _contentResolver.Setup(r => r.Resolve(nodeKey, docType, out isActualContent)).Returns(content);
+        _blockPreviewService
+            .Setup(s => s.GetStylesheetPaths(BlockType.BlockGrid, content, It.IsAny<ControllerContext>()))
+            .ReturnsAsync(new List<string> { "/css/grid.css" });
+
+        var result = await _controller.GetGridStylesheets(nodeKey, docType);
+
+        var ok = result as OkObjectResult;
+        Assert.That(ok, Is.Not.Null);
+        Assert.That(ok!.Value, Is.EqualTo(new List<string> { "/css/grid.css" }));
+        _contentResolver.Verify(r => r.Resolve(nodeKey, docType, out isActualContent), Times.Once);
+    }
+}

--- a/tests/Umbraco.Community.BlockPreview.Tests/Services/BlockPreviewServiceTests.cs
+++ b/tests/Umbraco.Community.BlockPreview.Tests/Services/BlockPreviewServiceTests.cs
@@ -52,15 +52,15 @@ public class BlockPreviewServiceTests
             .ReturnsAsync("<div>rendered</div>");
 
         // BlockEditorConverter can't be mocked directly (concrete Umbraco type with internal
-        // dependencies not exposed via any interface) and is passed null here. None of the five
-        // tests below reach FindBlockType (each returns from an earlier guard clause — invalid
+        // dependencies not exposed via any interface) and is passed null here. Five of the six
+        // tests below never reach FindBlockType (each returns from an earlier guard clause — invalid
         // block data, invalid content key, or an unresolvable element), so this is safe for what
-        // they test. The "no generated models" branch (FindBlockType returning null) genuinely
-        // isn't unit-testable without a real BlockEditorConverter or a running Umbraco host —
-        // it stays covered only by the manual smoke test in Task 4's Step 6, matching how the
-        // pre-refactor BlockPreviewService (zero tests before this task) covered it. Do not
-        // "fix" this by constructing a real BlockEditorConverter; that needs an IPublishedModelFactory
-        // + content-cache dependency graph well beyond this task's scope.
+        // they test. The sixth test (RenderGridBlock_WithMatchingLayout_AppliesRowAndColumnSpanBeforeRendering)
+        // needs FindBlockType and uses the TestableBlockPreviewService subclass below to bypass the real,
+        // unmockable BlockEditorConverter instead of constructing one. The "no generated models" branch
+        // (FindBlockType returning null) genuinely isn't unit-testable without a real BlockEditorConverter or a
+        // running Umbraco host — it stays covered only by the manual smoke test in Task 4's Step 6, matching
+        // how the pre-refactor BlockPreviewService (zero tests before this task) covered it.
         _service = new BlockPreviewService(
             _publishedModelFactory.Object,
             blockEditorConverter: null!,

--- a/tests/Umbraco.Community.BlockPreview.Tests/Services/BlockPreviewServiceTests.cs
+++ b/tests/Umbraco.Community.BlockPreview.Tests/Services/BlockPreviewServiceTests.cs
@@ -134,4 +134,110 @@ public class BlockPreviewServiceTests
 
         Assert.That(result, Does.Contain(Constants.ErrorMessages.InvalidContentData));
     }
+
+    [Test]
+    public async Task RenderGridBlock_WithMatchingLayout_AppliesRowAndColumnSpanBeforeRendering()
+    {
+        // Exercises the `configure` callback wired up in RenderGridBlock (BlockPreviewService.cs),
+        // which threads GetMatchingGridLayout's matched RowSpan/ColumnSpan onto the created block
+        // instance. This path had zero test coverage before, because it requires a real BlockGridItem
+        // instance (not mockable) and previously required the real, unmockable BlockEditorConverter to
+        // reach FindBlockType. FindBlockType is now `protected virtual` (source/binary compatible change)
+        // specifically so TestableBlockPreviewService below can bypass it.
+        var contentTypeKey = Guid.NewGuid();
+        var documentTypeUnique = Guid.NewGuid();
+        var dataTypeKey = Guid.NewGuid();
+        const string blockEditorAlias = "myGrid";
+
+        var layoutItem = new BlockGridLayoutItem(_contentKey) { RowSpan = 3, ColumnSpan = 6 };
+        var blockGridValue = new BlockGridValue(new[] { layoutItem })
+        {
+            ContentData = new List<BlockItemData> { new(_contentKey, contentTypeKey, "myElement") }
+        };
+        var blockEditorData = new BlockEditorData<BlockGridValue, BlockGridLayoutItem>(
+            Array.Empty<ContentAndSettingsReference>(), blockGridValue);
+
+        _blockDataConverter.Setup(c => c.DeserializeBlockGrid(It.IsAny<string>())).Returns(blockEditorData);
+
+        var blockGridConfig = new BlockGridConfiguration
+        {
+            Blocks = new[]
+            {
+                new BlockGridConfiguration.BlockGridBlockConfiguration
+                {
+                    ContentElementTypeKey = contentTypeKey,
+                    Areas = Array.Empty<BlockGridConfiguration.BlockGridAreaConfiguration>()
+                }
+            }
+        };
+
+        var propertyType = Mock.Of<IPropertyType>(p => p.Alias == blockEditorAlias && p.DataTypeKey == dataTypeKey);
+        var documentType = Mock.Of<IContentType>(c =>
+            c.PropertyTypes == new List<IPropertyType> { propertyType } &&
+            c.CompositionPropertyTypes == new List<IPropertyType>());
+        var dataType = Mock.Of<IDataType>(d => d.ConfigurationObject == (object)blockGridConfig);
+
+        _blockTypeCacheService.Setup(s => s.GetContentType(documentTypeUnique)).ReturnsAsync(documentType);
+        _blockTypeCacheService.Setup(s => s.GetDataType(dataTypeKey)).ReturnsAsync(dataType);
+
+        var blockInstance = new BlockGridItem(_contentKey, _contentElement, null, null);
+        _blockModelFactory
+            .Setup(f => f.CreateBlockInstance(BlockType.BlockGrid, typeof(object), _contentElement, null, null, _contentKey, null))
+            .Returns(blockInstance);
+
+        BlockPreviewContext? capturedContext = null;
+        _blockViewRenderer
+            .Setup(r => r.RenderAsync(It.IsAny<BlockPreviewContext>(), It.IsAny<ViewEngineResult?>()))
+            .Callback<BlockPreviewContext, ViewEngineResult?>((ctx, _) => capturedContext = ctx)
+            .ReturnsAsync("<div>grid</div>");
+
+        var service = new TestableBlockPreviewService(
+            _publishedModelFactory.Object,
+            blockEditorConverter: null!,
+            Microsoft.Extensions.Options.Options.Create(new BlockPreviewOptions()),
+            _jsonSerializer.Object,
+            _blockModelFactory.Object,
+            _blockViewRenderer.Object,
+            _blockDataConverter.Object,
+            _blockTypeCacheService.Object,
+            _viewResolver.Object);
+
+        var result = await service.RenderGridBlock(
+            "{}", _content, new ControllerContext(), blockEditorAlias, documentTypeUnique,
+            contentKey: _contentKey.ToString());
+
+        Assert.That(result, Is.EqualTo("<div>grid</div>"));
+        Assert.That(capturedContext, Is.Not.Null);
+        var renderedInstance = capturedContext!.ViewData?.Model as BlockGridItem;
+        Assert.That(renderedInstance, Is.Not.Null);
+        Assert.That(renderedInstance!.RowSpan, Is.EqualTo(3));
+        Assert.That(renderedInstance!.ColumnSpan, Is.EqualTo(6));
+    }
+
+    /// <summary>
+    /// Subclass that bypasses the real (unmockable, sealed) <see cref="BlockEditorConverter"/> by
+    /// overriding the now-<c>protected virtual</c> <c>FindBlockType</c> to always return a known
+    /// type, so tests can drive the rest of the render pipeline (including the Block Grid
+    /// `configure` callback) without a running Umbraco host.
+    /// </summary>
+    private class TestableBlockPreviewService : BlockPreviewService
+    {
+        public TestableBlockPreviewService(
+            IPublishedModelFactory publishedModelFactory,
+            BlockEditorConverter blockEditorConverter,
+            Microsoft.Extensions.Options.IOptions<BlockPreviewOptions> options,
+            IJsonSerializer jsonSerializer,
+            IBlockModelFactory blockModelFactory,
+            IBlockViewRenderer blockViewRenderer,
+            IBlockDataConverter blockDataConverter,
+            IBlockTypeCacheService blockTypeCacheService,
+            IBlockPreviewViewResolver viewResolver)
+            : base(
+                publishedModelFactory, blockEditorConverter, options, jsonSerializer, blockModelFactory,
+                blockViewRenderer, blockDataConverter, blockTypeCacheService, viewResolver)
+        {
+        }
+
+        protected override Type? FindBlockType(IPublishedContentType? contentType) => typeof(object);
+    }
 }

--- a/tests/Umbraco.Community.BlockPreview.Tests/Services/BlockPreviewServiceTests.cs
+++ b/tests/Umbraco.Community.BlockPreview.Tests/Services/BlockPreviewServiceTests.cs
@@ -1,0 +1,137 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ViewEngines;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Cache.PropertyEditors;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Blocks;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.PropertyEditors.ValueConverters;
+using Umbraco.Cms.Core.Serialization;
+using Umbraco.Community.BlockPreview.Enums;
+using Umbraco.Community.BlockPreview.Interfaces;
+using Umbraco.Community.BlockPreview.Services;
+
+namespace Umbraco.Community.BlockPreview.Tests.Services;
+
+[TestFixture]
+public class BlockPreviewServiceTests
+{
+    private Mock<IPublishedModelFactory> _publishedModelFactory = null!;
+    private Mock<IJsonSerializer> _jsonSerializer = null!;
+    private Mock<IBlockModelFactory> _blockModelFactory = null!;
+    private Mock<IBlockViewRenderer> _blockViewRenderer = null!;
+    private Mock<IBlockDataConverter> _blockDataConverter = null!;
+    private Mock<IBlockTypeCacheService> _blockTypeCacheService = null!;
+    private Mock<IBlockPreviewViewResolver> _viewResolver = null!;
+    private BlockPreviewService _service = null!;
+
+    private readonly Guid _contentKey = Guid.NewGuid();
+    private IPublishedContent _content = null!;
+    private IPublishedElement _contentElement = null!;
+    private IPublishedContentType _contentType = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _publishedModelFactory = new Mock<IPublishedModelFactory>();
+        _jsonSerializer = new Mock<IJsonSerializer>();
+        _blockModelFactory = new Mock<IBlockModelFactory>();
+        _blockViewRenderer = new Mock<IBlockViewRenderer>();
+        _blockDataConverter = new Mock<IBlockDataConverter>();
+        _blockTypeCacheService = new Mock<IBlockTypeCacheService>();
+        _viewResolver = new Mock<IBlockPreviewViewResolver>();
+
+        _contentType = Mock.Of<IPublishedContentType>(t => t.Alias == "myElement" && t.Key == Guid.NewGuid());
+        _contentElement = Mock.Of<IPublishedElement>(e => e.ContentType == _contentType);
+        _content = Mock.Of<IPublishedContent>();
+
+        _blockDataConverter.Setup(c => c.ConvertToElement(It.IsAny<BlockItemData>(), _content)).Returns(_contentElement);
+        _blockViewRenderer.Setup(r => r.RenderAsync(It.IsAny<BlockPreviewContext>(), It.IsAny<ViewEngineResult?>()))
+            .ReturnsAsync("<div>rendered</div>");
+
+        // BlockEditorConverter can't be mocked directly (concrete Umbraco type with internal
+        // dependencies not exposed via any interface) and is passed null here. None of the five
+        // tests below reach FindBlockType (each returns from an earlier guard clause — invalid
+        // block data, invalid content key, or an unresolvable element), so this is safe for what
+        // they test. The "no generated models" branch (FindBlockType returning null) genuinely
+        // isn't unit-testable without a real BlockEditorConverter or a running Umbraco host —
+        // it stays covered only by the manual smoke test in Task 4's Step 6, matching how the
+        // pre-refactor BlockPreviewService (zero tests before this task) covered it. Do not
+        // "fix" this by constructing a real BlockEditorConverter; that needs an IPublishedModelFactory
+        // + content-cache dependency graph well beyond this task's scope.
+        _service = new BlockPreviewService(
+            _publishedModelFactory.Object,
+            blockEditorConverter: null!,
+            Microsoft.Extensions.Options.Options.Create(new BlockPreviewOptions()),
+            _jsonSerializer.Object,
+            _blockModelFactory.Object,
+            _blockViewRenderer.Object,
+            _blockDataConverter.Object,
+            _blockTypeCacheService.Object,
+            _viewResolver.Object);
+    }
+
+    [Test]
+    public async Task RenderListBlock_WithInvalidBlockData_ReturnsInvalidBlockDataError()
+    {
+        _blockDataConverter.Setup(c => c.DeserializeBlockList(It.IsAny<string>())).Returns((BlockEditorData<BlockListValue, BlockListLayoutItem>?)null);
+
+        var result = await _service.RenderListBlock("not-json", _content, new ControllerContext());
+
+        Assert.That(result, Does.Contain(Constants.ErrorMessages.InvalidBlockData));
+    }
+
+    [Test]
+    public async Task RenderListBlock_WithUnknownContentKey_ReturnsInvalidContentKeyError()
+    {
+        var value = new BlockListValue { ContentData = new List<BlockItemData> { new(_contentKey, Guid.NewGuid(), "myElement") } };
+        _blockDataConverter.Setup(c => c.DeserializeBlockList(It.IsAny<string>()))
+            .Returns(new BlockEditorData<BlockListValue, BlockListLayoutItem>(Array.Empty<ContentAndSettingsReference>(), value));
+
+        var result = await _service.RenderListBlock("{}", _content, new ControllerContext(), contentKey: "not-a-guid");
+
+        Assert.That(result, Does.Contain(Constants.ErrorMessages.InvalidContentKey));
+    }
+
+    [Test]
+    public async Task RenderListBlock_WithUnresolvableElement_ReturnsInvalidContentDataError()
+    {
+        var value = new BlockListValue { ContentData = new List<BlockItemData> { new(_contentKey, Guid.NewGuid(), "myElement") } };
+        _blockDataConverter.Setup(c => c.DeserializeBlockList(It.IsAny<string>()))
+            .Returns(new BlockEditorData<BlockListValue, BlockListLayoutItem>(Array.Empty<ContentAndSettingsReference>(), value));
+        _blockDataConverter.Setup(c => c.ConvertToElement(It.IsAny<BlockItemData>(), _content)).Returns((IPublishedElement)null!);
+
+        var result = await _service.RenderListBlock("{}", _content, new ControllerContext(), contentKey: _contentKey.ToString());
+
+        Assert.That(result, Does.Contain(Constants.ErrorMessages.InvalidContentData));
+    }
+
+    [Test]
+    public async Task RenderSingleBlock_UsesTheSameSharedTailAsRenderListBlock()
+    {
+        // Same fixture as RenderListBlock's unresolvable-element case, proving Single
+        // routes through the identical shared helper (both cast to BlockListItem).
+        var value = new SingleBlockValue { ContentData = new List<BlockItemData> { new(_contentKey, Guid.NewGuid(), "myElement") } };
+        _blockDataConverter.Setup(c => c.DeserializeSingleBlock(It.IsAny<string>()))
+            .Returns(new BlockEditorData<SingleBlockValue, SingleBlockLayoutItem>(Array.Empty<ContentAndSettingsReference>(), value));
+        _blockDataConverter.Setup(c => c.ConvertToElement(It.IsAny<BlockItemData>(), _content)).Returns((IPublishedElement)null!);
+
+        var result = await _service.RenderSingleBlock("{}", _content, new ControllerContext(), contentKey: _contentKey.ToString());
+
+        Assert.That(result, Does.Contain(Constants.ErrorMessages.InvalidContentData));
+    }
+
+    [Test]
+    public async Task RenderRichTextBlock_WithNoContentData_ReturnsInvalidContentDataError()
+    {
+        var value = new RichTextBlockValue { ContentData = new List<BlockItemData>() };
+        _blockDataConverter.Setup(c => c.DeserializeRichText(It.IsAny<string>()))
+            .Returns(new BlockEditorData<RichTextBlockValue, RichTextBlockLayoutItem>(Array.Empty<ContentAndSettingsReference>(), value));
+
+        var result = await _service.RenderRichTextBlock("{}", _content, new ControllerContext());
+
+        Assert.That(result, Does.Contain(Constants.ErrorMessages.InvalidContentData));
+    }
+}

--- a/tests/Umbraco.Community.BlockPreview.Tests/Services/MarkupSanitizerTests.cs
+++ b/tests/Umbraco.Community.BlockPreview.Tests/Services/MarkupSanitizerTests.cs
@@ -1,0 +1,48 @@
+using NUnit.Framework;
+using Umbraco.Community.BlockPreview.Services;
+
+namespace Umbraco.Community.BlockPreview.Tests.Services;
+
+[TestFixture]
+public class MarkupSanitizerTests
+{
+    private MarkupSanitizer _sanitizer = null!;
+
+    [SetUp]
+    public void SetUp() => _sanitizer = new MarkupSanitizer();
+
+    [Test]
+    public void CleanUp_WithNullOrWhitespace_ReturnsInputUnchanged()
+    {
+        Assert.That(_sanitizer.CleanUp(""), Is.EqualTo(""));
+        Assert.That(_sanitizer.CleanUp("   "), Is.EqualTo("   "));
+    }
+
+    [Test]
+    public void CleanUp_RewritesAnchorHrefsAndMarksThemAsBlockPreviewLinks()
+    {
+        var result = _sanitizer.CleanUp("<a href=\"/some/page\">link</a>");
+
+        Assert.That(result, Does.Contain("href=\"javascript:;\""));
+        Assert.That(result, Does.Contain("data-block-preview-link=\"true\""));
+    }
+
+    [Test]
+    public void CleanUp_DisablesFormElements()
+    {
+        var result = _sanitizer.CleanUp("<input type=\"text\" /><textarea></textarea><select></select><button>Go</button>");
+
+        Assert.That(result, Does.Match("<input[^>]*disabled=\"disabled\""));
+        Assert.That(result, Does.Match("<textarea[^>]*disabled=\"disabled\""));
+        Assert.That(result, Does.Match("<select[^>]*disabled=\"disabled\""));
+        Assert.That(result, Does.Match("<button[^>]*disabled=\"disabled\""));
+    }
+
+    [Test]
+    public void CleanUp_WithNoLinksOrForms_LeavesMarkupIntact()
+    {
+        var result = _sanitizer.CleanUp("<div class=\"hero\"><h1>Title</h1></div>");
+
+        Assert.That(result, Is.EqualTo("<div class=\"hero\"><h1>Title</h1></div>"));
+    }
+}

--- a/tests/Umbraco.Community.BlockPreview.Tests/Services/PreviewContentResolverTests.cs
+++ b/tests/Umbraco.Community.BlockPreview.Tests/Services/PreviewContentResolverTests.cs
@@ -1,0 +1,128 @@
+using Microsoft.Extensions.Caching.Memory;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.PublishedCache;
+using Umbraco.Cms.Core.Routing;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Web;
+using Umbraco.Cms.Infrastructure.Scoping;
+using Umbraco.Community.BlockPreview.Services;
+
+namespace Umbraco.Community.BlockPreview.Tests.Services;
+
+[TestFixture]
+public class PreviewContentResolverTests
+{
+    private Mock<IUmbracoContextAccessor> _umbracoContextAccessor = null!;
+    private Mock<ILanguageService> _languageService = null!;
+    private ContextCultureService _contextCultureService = null!;
+    private Mock<IPublishedContentTypeCache> _contentTypeCache = null!;
+    private Mock<IDocumentCacheService> _documentCacheService = null!;
+    private Mock<IScopeProvider> _scopeProvider = null!;
+    private Mock<IAppPolicyCache> _runtimeCache = null!;
+    private Mock<IVariationContextAccessor> _variationContextAccessor = null!;
+    private PreviewContentResolver _resolver = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _umbracoContextAccessor = new Mock<IUmbracoContextAccessor>();
+        _languageService = new Mock<ILanguageService>();
+        // ContextCultureService has no parameterless constructor and no getter — it only
+        // writes into IVariationContextAccessor.VariationContext via SetCulture. Construct
+        // it with a mocked accessor and assert against that mock, not against the service.
+        _variationContextAccessor = new Mock<IVariationContextAccessor>();
+        _contextCultureService = new ContextCultureService(_variationContextAccessor.Object);
+        _contentTypeCache = new Mock<IPublishedContentTypeCache>();
+        _documentCacheService = new Mock<IDocumentCacheService>();
+        _scopeProvider = new Mock<IScopeProvider>();
+        _runtimeCache = new Mock<IAppPolicyCache>();
+
+        // Runtime cache: IAppPolicyCache.Get is the interface member the GetCacheItem<T>
+        // extension method delegates to under the hood (verified by reflection against the
+        // real Umbraco.Cms.Core 17.3.0 assembly — GetCacheItem is not itself an interface
+        // member, so it can't be mocked directly). Run the factory delegate immediately, no
+        // actual caching.
+        _runtimeCache
+            .Setup(c => c.Get(It.IsAny<string>(), It.IsAny<Func<object?>>(), It.IsAny<TimeSpan?>(),
+                It.IsAny<bool>()))
+            .Returns((string _, Func<object?> factory, TimeSpan? _, bool _) => factory());
+
+        var scopeMock = new Mock<Umbraco.Cms.Infrastructure.Scoping.IScope>();
+        _scopeProvider.Setup(s => s.CreateScope(
+            It.IsAny<System.Data.IsolationLevel>(),
+            It.IsAny<Umbraco.Cms.Core.Scoping.RepositoryCacheMode>(),
+            It.IsAny<Umbraco.Cms.Core.Events.IEventDispatcher>(),
+            It.IsAny<Umbraco.Cms.Core.Events.IScopedNotificationPublisher>(),
+            It.IsAny<bool?>(),
+            It.IsAny<bool>(),
+            It.IsAny<bool>())).Returns(scopeMock.Object);
+
+        _resolver = new PreviewContentResolver(
+            _umbracoContextAccessor.Object,
+            Mock.Of<IPublishedRouter>(),
+            _languageService.Object,
+            _contextCultureService,
+            _contentTypeCache.Object,
+            _documentCacheService.Object,
+            _scopeProvider.Object,
+            _runtimeCache.Object);
+    }
+
+    [Test]
+    public void Resolve_WithNoUmbracoContext_ReturnsNull()
+    {
+        IUmbracoContext? context = null;
+        _umbracoContextAccessor
+            .Setup(a => a.TryGetUmbracoContext(out context))
+            .Returns(false);
+
+        var result = _resolver.Resolve(Guid.NewGuid(), Guid.NewGuid(), out bool isActualContent);
+
+        Assert.That(result, Is.Null);
+        Assert.That(isActualContent, Is.False);
+    }
+
+    [Test]
+    public async Task ResolveCultureAsync_WithExplicitCulture_UsesItAndSetsContextCulture()
+    {
+        var culture = await _resolver.ResolveCultureAsync("da-DK", content: null);
+
+        Assert.That(culture, Is.EqualTo("da-DK"));
+        _variationContextAccessor.VerifySet(
+            a => a.VariationContext = It.Is<VariationContext>(vc => vc.Culture == "da-DK"), Times.Once);
+    }
+
+    [Test]
+    public async Task ResolveCultureAsync_WithUndefinedString_FallsBackToDefaultLanguage()
+    {
+        _languageService.Setup(l => l.GetAllAsync())
+            .ReturnsAsync(new List<Umbraco.Cms.Core.Models.ILanguage>
+            {
+                Mock.Of<Umbraco.Cms.Core.Models.ILanguage>(l => l.IsoCode == "en-US"),
+                Mock.Of<Umbraco.Cms.Core.Models.ILanguage>(l => l.IsoCode == "da-DK"),
+            });
+        _languageService.Setup(l => l.GetDefaultIsoCodeAsync()).ReturnsAsync("en-US");
+
+        var culture = await _resolver.ResolveCultureAsync("undefined", content: null);
+
+        Assert.That(culture, Is.EqualTo("en-US"));
+    }
+
+    [Test]
+    public async Task ResolveCultureAsync_WithSingleConfiguredLanguage_UsesItRegardlessOfDefaultFlag()
+    {
+        _languageService.Setup(l => l.GetAllAsync())
+            .ReturnsAsync(new List<Umbraco.Cms.Core.Models.ILanguage>
+            {
+                Mock.Of<Umbraco.Cms.Core.Models.ILanguage>(l => l.IsoCode == "da-DK"),
+            });
+
+        var culture = await _resolver.ResolveCultureAsync(null, content: null);
+
+        Assert.That(culture, Is.EqualTo("da-DK"));
+        _languageService.Verify(l => l.GetDefaultIsoCodeAsync(), Times.Never);
+    }
+}

--- a/tests/Umbraco.Community.BlockPreview.Tests/Services/PreviewRequestExecutorTests.cs
+++ b/tests/Umbraco.Community.BlockPreview.Tests/Services/PreviewRequestExecutorTests.cs
@@ -1,0 +1,176 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Community.BlockPreview.Interfaces;
+using Umbraco.Community.BlockPreview.Services;
+
+namespace Umbraco.Community.BlockPreview.Tests.Services;
+
+[TestFixture]
+public class PreviewRequestExecutorTests
+{
+    private Mock<IPreviewContentResolver> _contentResolver = null!;
+    private Mock<IBlockPreviewRequestEnricher> _requestEnricher = null!;
+    private Mock<IBlockPreviewResponseEnricher> _responseEnricher = null!;
+    private Mock<IAppPolicyCache> _runtimeCache = null!;
+    private Mock<ITypeFinder> _typeFinder = null!;
+    private Mock<ILogger<PreviewRequestExecutor>> _logger = null!;
+    private PreviewRequestExecutor _executor = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _contentResolver = new Mock<IPreviewContentResolver>();
+        _requestEnricher = new Mock<IBlockPreviewRequestEnricher>();
+        _responseEnricher = new Mock<IBlockPreviewResponseEnricher>();
+        _runtimeCache = new Mock<IAppPolicyCache>();
+        _typeFinder = new Mock<ITypeFinder>();
+        _logger = new Mock<ILogger<PreviewRequestExecutor>>();
+
+        // IAppPolicyCache.GetCacheItem<T>(...) is an extension method (Umbraco.Extensions.AppCacheExtensions),
+        // not a mockable interface member — it delegates to IAppPolicyCache.Get(string, Func<object?>, TimeSpan?, bool).
+        // Mock that instead, matching Task 2's PreviewContentResolverTests.
+        _runtimeCache
+            .Setup(c => c.Get(It.IsAny<string>(), It.IsAny<Func<object?>>(), It.IsAny<TimeSpan?>(), It.IsAny<bool>()))
+            .Returns((string _, Func<object?> factory, TimeSpan? _, bool _) => factory());
+
+        _responseEnricher
+            .Setup(e => e.EnrichAsync(It.IsAny<string>(), It.IsAny<HttpContext>(), It.IsAny<IPublishedContent?>(),
+                It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<int?>()))
+            .ReturnsAsync((string markup, HttpContext _, IPublishedContent? _, string? _, string? _, string? _, string? _, int? _) => markup);
+
+        _executor = new PreviewRequestExecutor(
+            _contentResolver.Object,
+            _requestEnricher.Object,
+            _responseEnricher.Object,
+            _runtimeCache.Object,
+            _typeFinder.Object,
+            _logger.Object);
+    }
+
+    private static PreviewRenderRequest BuildRequest(HttpContext? httpContext = null) => new(
+        BlockData: "{}",
+        NodeKey: Guid.NewGuid(),
+        BlockEditorAlias: "myBlockGrid",
+        ContentElementAlias: "myElement",
+        Culture: "en-US",
+        DocumentTypeUnique: Guid.NewGuid(),
+        ContentUdi: "umb://element/abc",
+        SettingsUdi: null,
+        BlockIndex: 0,
+        HttpContext: httpContext ?? DefaultHttpContextWithHost(),
+        ControllerContext: new ControllerContext());
+
+    // A bare `new DefaultHttpContext()` has an empty Scheme and Host, so
+    // Request.GetDisplayUrl() (called by the executor to build the SetupPublishedRequestAsync
+    // Uri) produces "://" — not a valid absolute URI. `new Uri("://")` then throws
+    // UriFormatException, which the executor's own catch block swallows into a generic error
+    // template, masking whatever the test under exercise actually intended to observe. Give the
+    // fake HttpContext a real scheme/host, as a real inbound request would have.
+    private static DefaultHttpContext DefaultHttpContextWithHost()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Scheme = "https";
+        httpContext.Request.Host = new HostString("localhost");
+        return httpContext;
+    }
+
+    [Test]
+    public async Task ExecuteAsync_WithoutGeneratedModels_ReturnsModelsBuilderWarningAndSkipsRender()
+    {
+        // ITypeFinder.FindClassesWithAttribute<T>() is an extension method (Umbraco.Extensions.TypeFinderExtensions),
+        // not a mockable interface member — it delegates to the non-generic
+        // ITypeFinder.FindClassesWithAttribute(Type, IEnumerable<Assembly>, bool). Mock that instead.
+        _typeFinder
+            .Setup(t => t.FindClassesWithAttribute(
+                typeof(Umbraco.Cms.Core.Models.PublishedContent.PublishedModelAttribute),
+                It.IsAny<IEnumerable<System.Reflection.Assembly>>(), It.IsAny<bool>()))
+            .Returns(Array.Empty<Type>());
+
+        var renderCalled = false;
+        var result = await _executor.ExecuteAsync(BuildRequest(), (_, _, _, _, _, _, _, _) =>
+        {
+            renderCalled = true;
+            return Task.FromResult("<div>rendered</div>");
+        });
+
+        Assert.That(renderCalled, Is.False);
+        Assert.That(result, Does.Contain(Constants.ErrorMessages.ModelsBuilderError));
+    }
+
+    [Test]
+    public async Task ExecuteAsync_WithGeneratedModels_ResolvesContentAndInvokesRenderWithIt()
+    {
+        _typeFinder
+            .Setup(t => t.FindClassesWithAttribute(
+                typeof(Umbraco.Cms.Core.Models.PublishedContent.PublishedModelAttribute),
+                It.IsAny<IEnumerable<System.Reflection.Assembly>>(), It.IsAny<bool>()))
+            .Returns(new[] { typeof(object) });
+
+        var content = Mock.Of<IPublishedContent>();
+        // IPreviewContentResolver.Resolve's 3rd parameter is `out bool isActualContent`, not an
+        // out IPublishedContent — the resolved content comes back via the return value instead.
+        bool isActualContent = true;
+        _contentResolver.Setup(r => r.Resolve(It.IsAny<Guid?>(), It.IsAny<Guid?>(), out isActualContent)).Returns(content);
+        _contentResolver.Setup(r => r.ResolveCultureAsync(It.IsAny<string?>(), content)).ReturnsAsync("en-US");
+
+        IPublishedContent? receivedContent = null;
+        var result = await _executor.ExecuteAsync(BuildRequest(), (_, c, _, _, _, _, _, _) =>
+        {
+            receivedContent = c;
+            return Task.FromResult("<div>rendered</div>");
+        });
+
+        Assert.That(receivedContent, Is.SameAs(content));
+        Assert.That(result, Is.EqualTo("<div>rendered</div>"));
+        _requestEnricher.Verify(e => e.EnrichAsync(
+            It.IsAny<HttpContext>(), content, "myBlockGrid", "myElement", "umb://element/abc", null, 0), Times.Once);
+    }
+
+    [Test]
+    public async Task ExecuteAsync_WhenRenderThrows_ReturnsErrorTemplateAndLogs()
+    {
+        _typeFinder
+            .Setup(t => t.FindClassesWithAttribute(
+                typeof(Umbraco.Cms.Core.Models.PublishedContent.PublishedModelAttribute),
+                It.IsAny<IEnumerable<System.Reflection.Assembly>>(), It.IsAny<bool>()))
+            .Returns(new[] { typeof(object) });
+
+        bool isActualContent = false;
+        _contentResolver.Setup(r => r.Resolve(It.IsAny<Guid?>(), It.IsAny<Guid?>(), out isActualContent)).Returns((IPublishedContent?)null);
+
+        var result = await _executor.ExecuteAsync(BuildRequest(), (_, _, _, _, _, _, _, _) =>
+            throw new InvalidOperationException("boom"));
+
+        Assert.That(result, Does.Contain("Something went wrong rendering a preview"));
+        Assert.That(result, Does.Contain("boom"));
+    }
+
+    [Test]
+    public async Task ExecuteAsync_PassesNullNotEmptyStringForOmittedRichTextArgs()
+    {
+        // Regression guard: the RTE controller action historically called the enrichers
+        // with only 4 of the 7 optional args, leaving contentUdi/settingsUdi/blockIndex at
+        // their `null` defaults — never empty string. A custom enricher may branch on that.
+        _typeFinder
+            .Setup(t => t.FindClassesWithAttribute(
+                typeof(Umbraco.Cms.Core.Models.PublishedContent.PublishedModelAttribute),
+                It.IsAny<IEnumerable<System.Reflection.Assembly>>(), It.IsAny<bool>()))
+            .Returns(new[] { typeof(object) });
+
+        bool isActualContent = false;
+        _contentResolver.Setup(r => r.Resolve(It.IsAny<Guid?>(), It.IsAny<Guid?>(), out isActualContent)).Returns((IPublishedContent?)null);
+
+        var rteRequest = BuildRequest() with { ContentUdi = null, SettingsUdi = null, BlockIndex = null };
+
+        await _executor.ExecuteAsync(rteRequest, (_, _, _, _, _, _, _, _) => Task.FromResult("<div/>"));
+
+        _requestEnricher.Verify(e => e.EnrichAsync(
+            It.IsAny<HttpContext>(), null, "myBlockGrid", "myElement", null, null, null), Times.Once);
+    }
+}

--- a/tests/Umbraco.Community.BlockPreview.Tests/Services/PreviewRequestExecutorTests.cs
+++ b/tests/Umbraco.Community.BlockPreview.Tests/Services/PreviewRequestExecutorTests.cs
@@ -147,8 +147,13 @@ public class PreviewRequestExecutorTests
         var result = await _executor.ExecuteAsync(BuildRequest(), (_, _, _, _, _, _, _, _) =>
             throw new InvalidOperationException("boom"));
 
-        Assert.That(result, Does.Contain("Something went wrong rendering a preview"));
-        Assert.That(result, Does.Contain("boom"));
+        Assert.That(result, Does.Contain(string.Format(Constants.ErrorMessages.RenderError, "boom")));
+        _logger.Verify(l => l.Log(
+            LogLevel.Error,
+            It.IsAny<EventId>(),
+            It.IsAny<It.IsAnyType>(),
+            It.IsAny<Exception>(),
+            It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.Once);
     }
 
     [Test]


### PR DESCRIPTION
## Summary

Extracts the duplicated pipeline logic in `BlockPreviewApiController` and `BlockPreviewService` into three focused, independently testable services, without changing any public behavior.

- **`IMarkupSanitizer`** — the markup-cleanup step previously inlined in the controller.
- **`IPreviewContentResolver`** — content/culture/published-request resolution, previously duplicated across the controller's actions.
- **`IPreviewRequestExecutor`** — the shared "check models exist → resolve → enrich → render → enrich → catch" pipeline, previously repeated across all four preview endpoints.
- `BlockPreviewService`'s four `Render*Block` methods now share one internal tail (`RenderTypedBlockAsync<TBlockItem>`) instead of duplicating ~60 lines each.

All three new services follow the existing "Replaceable Services" pattern already used by `IBlockModelFactory`/`IBlockViewRenderer`/`IBlockDataConverter`, and are documented in `docs/advanced-customization.md` alongside them.

**No public behavior changes.** `IBlockPreviewService`'s interface and its three documented overridable methods (`GetViewResult`, `CreateViewDataAsync`, `GetStylesheetPaths`) are byte-identical to before. The controller's HTTP contract (routes, params, response shapes) is unchanged. The obsolete 14-parameter fallback constructor was removed (an intentional, suppressed APICompat break — see `CompatibilitySuppressions.xml`, following the existing precedent for `AddInternal`'s visibility change).

Both the controller and the service have unit test coverage for the first time.

## Test plan

- [x] `dotnet test` — 91/91 passing
- [x] Two rounds of automated code review (task-level + whole-branch), both approved with fixes applied
- [ ] Manual backoffice smoke test (all four block editor types) — not run this cycle, no browser access available; recommend running before a release tag, particularly around Block Grid area rendering with row/column spans

🤖 Generated with [Claude Code](https://claude.com/claude-code)